### PR TITLE
changed mapped mem sgmt so it never flushes in its implementation

### DIFF
--- a/src/lib/util/memory_segment_mapped.cc
+++ b/src/lib/util/memory_segment_mapped.cc
@@ -174,7 +174,6 @@ struct MemorySegmentMapped::Impl {
     void growSegment() {
         // We first need to unmap it before calling grow().
         const size_t prev_size = base_sgmt_->get_size();
-        base_sgmt_->flush();
         base_sgmt_.reset();
 
         // Double the segment size.  In theory, this process could repeat
@@ -279,7 +278,6 @@ MemorySegmentMapped::MemorySegmentMapped(const std::string& filename,
 MemorySegmentMapped::~MemorySegmentMapped() {
     if (impl_->base_sgmt_ && !impl_->read_only_) {
         impl_->freeReservedMemory();
-        impl_->base_sgmt_->flush(); // note: this is exception free
     }
     delete impl_;
 }
@@ -420,7 +418,6 @@ MemorySegmentMapped::shrinkToFit() {
     }
 
     // First, unmap the underlying file.
-    impl_->base_sgmt_->flush();
     impl_->base_sgmt_.reset();
 
     BaseSegment::shrink_to_fit(impl_->filename_.c_str());

--- a/src/lib/util/memory_segment_mapped.h
+++ b/src/lib/util/memory_segment_mapped.h
@@ -56,6 +56,14 @@ namespace util {
 /// segments in read-only mode for the same file, but that shouldn't be
 /// necessary in practice; since it's read-only there wouldn't be a reason
 /// to have a redundant copy.
+///
+/// This implementation does not flush dirty memory pages to the disk on
+/// destruction for performance reasons.  This means if the mapped file image
+/// may be corrupted after an unexpected system crash and reboot.  In our
+/// expected usage this shouldn't be a problem, since the mapped image is only
+/// used as a cache, and corrupted image will be detected and discarded with
+/// checksums.  If a future extension requires more robustness, we can then
+/// consider adding a "synchronous" mode.
 class MemorySegmentMapped : boost::noncopyable, public MemorySegment {
 public:
     /// \brief The default value of the mapped file size when newly created.


### PR DESCRIPTION
experiments showed it could cause a non-negligible performance impact.
and, as commented, we actually shouldn't need such strict robustness.

See also the code comments.  It passed unit tests and some local experiments.
