### PR TITLE
[xfrout] (big) refactoring: use BUNDYServer to eliminate intermediate thread.

### DIFF
--- a/src/bin/xfrout/tests/xfrout_test.py.in
+++ b/src/bin/xfrout/tests/xfrout_test.py.in
@@ -1773,7 +1773,7 @@ class MyXfroutServer(XfroutServer):
             bundy.config.module_spec_from_file(xfrout.SPECFILE_LOCATION)
         self._counters = xfrout.Counters(xfrout.SPECFILE_LOCATION)
 
-class TestXfroutServer(unittest.TestCase):
+class TestOldXfroutServer(unittest.TestCase):
     def setUp(self):
         self.xfrout_server = MyXfroutServer()
 
@@ -1786,6 +1786,506 @@ class TestXfroutServer(unittest.TestCase):
         self.assertEqual(
             self.xfrout_server.command_handler('getstats', None), \
                 create_answer(0,  {}))
+
+# Used in TestXfroutServer below
+class MockCC(MockModuleCCSession, ConfigData):
+    def __init__(self, specfile, config_handler, command_handler):
+        super().__init__()
+        module_spec = bundy.config.module_spec_from_file(
+            xfrout.SPECFILE_LOCATION)
+        ConfigData.__init__(self, module_spec)
+
+        self.add_remote_params = [] # params placeholder for inspection
+        self.add_remote_exception = None # to raise exception from the method
+        self.__config_handler = config_handler
+
+    def start(self):
+        pass
+
+    def get_remote_config_value(self, module_name, identifier):
+        if module_name == "Auth" and identifier == "database_file":
+            return "initdb.file", False
+
+    def add_remote_config(self, specfile, handler=None):
+        if self.add_remote_exception is not None:
+            raise self.add_remote_exception
+        self.add_remote_params.append((specfile, handler))
+
+class MockXfroutServer(xfrout.NewXfroutServer):
+    def __init__(self):
+        self.rcallbacks = {}
+        super().__init__()
+
+    def _setup_ccsession(self):
+        orig_cls = bundy.config.ModuleCCSession
+        bundy.config.ModuleCCSession = MockCC
+        try:
+            super()._setup_ccsession()
+        finally:
+            bundy.config.ModuleCCSession = orig_cls
+
+    # In the following two, we simply assume it's an for reading
+    def watch_fileno(self, fileno, rcallback):
+        self.rcallbacks[fileno] = rcallback
+
+    def unwatch_fileno(self, fileno, r, w, x):
+        del self.rcallbacks[fileno]
+
+class MockNotifyOut(notify_out.NotifyOut):
+    def __init__(self, sqlite3_dbfile=None, counters=None):
+        # The attributes are to be used for inspection by tests
+        self.init_params = (sqlite3_dbfile, counters)
+        self.add_slave_params = []
+        self.dispatcher_params = []
+
+    def add_slave(self, address, port):
+        self.add_slave_params.append((address, port))
+
+    def dispatcher(self, daemon):
+        self.dispatcher_params.append(daemon)
+
+    def shutdown(self):
+        self.shutdown_called = True # allow inspection
+
+    def send_notify(self, address, port):
+        self.send_notify_params = (address, port)
+
+class FakeSocket:
+    """A fake socket: pretending to be Python socket API with hardcoded params.
+
+    """
+    def __init__(self, fileno, proto=socket.IPPROTO_TCP):
+        self.proto = proto
+        self.family = socket.AF_INET6 # arbitrary choice
+        self.type = socket.SOCK_STREAM
+        self.__fileno = fileno
+    def fileno(self):
+        return self.__fileno
+    def accept(self):
+        return FakeSocket(self.__fileno + 1), '/dummy/path'
+    def close(self):
+        self.closed = True
+
+# borrowed from ddns tests.  for a longer term we should unify these.
+class FakeSessionReceiver:
+    """A fake socket session receiver, for our tests."""
+    def __init__(self, socket):
+        self._socket = socket
+
+    def socket(self):
+        """
+        This method is not present in the real receiver, but we use it to
+        inspect the socket passed to the constructor.
+        """
+        return self._socket
+
+# A simple lightweight fake of the Python Thread class.  It actually doesn't
+# spawn a thread; the start() method simply calls the target passed to the
+# constructor from the main thread.
+class FakeThread:
+    def __init__(self, target, args):
+        self.__target = target
+        self.__args = args
+        self.daemon = False
+
+    def start(self):
+        assert(self.daemon)     # in our usage threads have to be daemonized
+        self.__target(*self.__args)
+
+class TestXfroutServer(unittest.TestCase):
+    def setUp(self):
+        self.__server = MockXfroutServer()
+
+        # Mock tsig_keyring module
+        self.__tsig_keyring_orig = bundy.server_common.tsig_keyring
+        bundy.server_common.tsig_keyring = self
+        self.__keyring_init_params = []
+
+        # Mock NotifyOut
+        self.__notify_out_orig = notify_out.NotifyOut
+        notify_out.NotifyOut = MockNotifyOut
+
+        self.__old_stdout = sys.stdout # maybe replaced in some tests
+        self.__temp_sock_file = 'temp.sock.file' # constant for some tests
+
+    def tearDown(self):
+        bundy.server_common.tsig_keyring = self.__tsig_keyring_orig
+        notify_out.NotifyOut = self.__notify_out_orig
+        sys.stdout = self.__old_stdout
+
+        # Creating (Mock)XfroutServer will create the well-known socket file,
+        # which would make some tests fail.
+        if os.path.exists(xfrout.UNIX_SOCKET_FILE):
+            os.unlink(xfrout.UNIX_SOCKET_FILE)
+
+        # Cleanup used temporary file so it won't confuse subsequent tests.
+        if os.path.exists(self.__temp_sock_file):
+            os.unlink(self.__temp_sock_file)
+
+    def init_keyring(self, ccs): # pretend to be tsig_keyring.init_keyring()
+        self.__keyring_init_params.append(ccs)
+
+    def get_keyring(self):
+        return 'test-ring'
+
+    def test_setup_module(self):
+        # minimal initialization with a faked initial config for 'also_notify'
+        self.__server._setup_ccsession()
+        self.__server._config_data = {
+            'also_notify': [{'address': '::1'}, {'port': 5300}]}
+
+        # Confirm the initial values of attributes that are to be set in
+        # _setup_module()
+        self.assertIsNone(self.__server._notifier)
+        self.assertEqual([], self.__keyring_init_params)
+        self.assertEqual([], self.__server.mod_ccsession.add_remote_params)
+
+        # Call the method
+        self.__server._setup_module()
+
+        # Confirm the setup results
+        self.assertEqual([self.__server.mod_ccsession],
+                         self.__keyring_init_params)
+        self.assertEqual([(xfrout.AUTH_SPECFILE_LOCATION, None)],
+                         self.__server.mod_ccsession.add_remote_params)
+        self.assertEqual((self.__server.get_db_file(), self.__server._counters),
+                         self.__server._notifier.init_params)
+        self.assertEqual([('::1', 53), ('', 5300)],
+                         self.__server._notifier.add_slave_params)
+        self.assertEqual([True], self.__server._notifier.dispatcher_params)
+
+    def test_shutdown_module(self):
+        # test case setup, mocking some methods that will be called in shutdown
+        def wait_for_threads():
+            self.__thread_joined = True
+        self.__server._notifier = MockNotifyOut()
+        self.__server._wait_for_threads = wait_for_threads
+
+        # call the method, then confirm its effect.
+        self.__server._shutdown_module()
+
+        # The listen socket should have been closed, so any socket operation
+        # should fail.
+        self.assertRaises(OSError, self.__server._listen_socket.getsockname)
+        self.assertFalse(os.path.exists(xfrout.UNIX_SOCKET_FILE))
+        self.assertTrue(self.__server._shutdown_event.is_set())
+        self.assertTrue(self.__server._notifier.shutdown_called)
+        self.assertTrue(self.__thread_joined)
+
+    def test_notify_command(self):
+        from bundy.config import parse_answer
+        self.__server._notifier = MockNotifyOut()
+
+        # A normal case.  Positive answer will be returned, and send_notify()
+        # will be called with given parameters
+        ans = self.__server._mod_command_handler('notify',
+                                                 {'zone_name': 'example.com',
+                                                  'zone_class': 'CH'})
+        self.assertEqual(1, parse_answer(ans)[0])
+        self.assertEqual(('example.com', 'CH'),
+                         self.__server._notifier.send_notify_params)
+
+        # zone class can be omitted
+        ans = self.__server._mod_command_handler('notify',
+                                                 {'zone_name': 'example.com'})
+        self.assertEqual(('example.com', 'IN'),
+                         self.__server._notifier.send_notify_params)
+
+        # address must be specified
+        ans = self.__server._mod_command_handler('notify',
+                                                 {'zone_class': 'IN'})
+        self.assertEqual(1, parse_answer(ans)[0])
+
+        # send_notify() returns a negative result, which considered an error
+        self.__server._notifier.send_notify = lambda n,c: False
+        ans = self.__server._mod_command_handler('notify',
+                                                 {'zone_name': 'example.com'})
+        self.assertEqual(1, parse_answer(ans)[0])
+
+    def test_getstats_command(self):
+        from bundy.config import parse_answer
+        ans = self.__server._mod_command_handler('getstats', None)
+        self.assertEqual(0, parse_answer(ans)[0])
+
+    def test_unkown_command(self):
+        from bundy.config import parse_answer
+        ans = self.__server._mod_command_handler('invalid', None)
+        self.assertEqual(1, parse_answer(ans)[0])
+
+    def __check_default_ACL(self):
+        context = bundy.acl.dns.RequestContext(socket.getaddrinfo(
+            "127.0.0.1", 1234, 0, socket.SOCK_DGRAM,socket.IPPROTO_UDP,
+            socket.AI_NUMERICHOST)[0][4])
+        self.assertEqual(bundy.acl.acl.ACCEPT,
+                         self.__server._acl.execute(context))
+
+    def __check_loaded_ACL(self, acl):
+        context = bundy.acl.dns.RequestContext(socket.getaddrinfo(
+            "127.0.0.1", 1234, 0, socket.SOCK_DGRAM, socket.IPPROTO_UDP,
+            socket.AI_NUMERICHOST)[0][4])
+        self.assertEqual(bundy.acl.acl.ACCEPT, acl.execute(context))
+        context = bundy.acl.dns.RequestContext(socket.getaddrinfo(
+            "192.0.2.1", 1234, 0, socket.SOCK_DGRAM, socket.IPPROTO_UDP,
+            socket.AI_NUMERICHOST)[0][4])
+        self.assertEqual(bundy.acl.acl.REJECT, acl.execute(context))
+
+    def test_update_config_data(self):
+        self.__server._setup_ccsession()
+        self.__server._config_handler({}) # initial config load
+        self.__check_default_ACL()
+        self.__server._config_handler({'transfers_out': 10})
+        self.assertEqual(self.__server._max_transfers_out, 10)
+        self.__check_default_ACL()
+
+        self.__server._config_handler({'transfers_out': 9})
+        self.assertEqual(self.__server._max_transfers_out, 9)
+
+        # Load the ACL
+        self.__server._config_handler({'transfer_acl': [{'from': '127.0.0.1',
+                                                         'action': 'ACCEPT'}]})
+        self.__check_loaded_ACL(self.__server._acl)
+        # Pass a wrong data there and check it does not replace the old one
+        ans = bundy.config.parse_answer(
+            self.__server._config_handler({'transfer_acl': ['Something bad']}))
+        self.assertEqual(1, ans[0])
+        self.__check_loaded_ACL(self.__server._acl)
+
+    def test_zone_config_data(self):
+        # By default, there's no specific zone config
+        self.__server._setup_ccsession()
+        self.__server._config_handler({}) # initial config load
+        self.assertEqual({}, self.__server._zone_config)
+
+        # Adding config for a specific zone.  The config is empty unless
+        # explicitly specified.
+        self.__server._config_handler({'zone_config':
+                                       [{'origin': 'example.com',
+                                         'class': 'IN'}]})
+        self.assertEqual({}, self.__server._zone_config[('IN', 'example.com.')])
+
+        # zone class can be omitted
+        self.__server._config_handler({'zone_config':
+                                       [{'origin': 'example.com'}]})
+        self.assertEqual({}, self.__server._zone_config[('IN', 'example.com.')])
+
+        # zone class, name are stored in the "normalized" form.  class
+        # strings are upper cased, names are down cased.
+        self.__server._config_handler({'zone_config':
+                                    [{'origin': 'EXAMPLE.com'}]})
+        self.assertEqual({}, self.__server._zone_config[('IN', 'example.com.')])
+
+        # invalid zone class, name will result in an error
+        ans = bundy.config.parse_answer(self.__server._config_handler(
+            {'zone_config': [{'origin': 'bad..example'}]}))
+        self.assertEqual(1, ans[0])
+        ans = bundy.config.parse_answer(self.__server._config_handler(
+            {'zone_config': [{'origin': 'example.com', 'class': 'badclass'}]}))
+        self.assertEqual(1, ans[0])
+
+        # Configuring a couple of more zones
+        self.__server._config_handler({'zone_config':
+                                       [{'origin': 'example.com'},
+                                        {'origin': 'example.com',
+                                         'class': 'CH'},
+                                        {'origin': 'example.org'}]})
+        self.assertEqual({}, self.__server._zone_config[('IN', 'example.com.')])
+        self.assertEqual({}, self.__server._zone_config[('CH', 'example.com.')])
+        self.assertEqual({}, self.__server._zone_config[('IN', 'example.org.')])
+
+        # Duplicate data: should be rejected with an error
+        ans = bundy.config.parse_answer(self.__server._config_handler(
+            {'zone_config': [{'origin': 'example.com'},
+                             {'origin': 'example.org'},
+                             {'origin': 'example.com'}]}))
+        self.assertEqual(1, ans[0])
+
+    def test_zone_config_data_with_acl(self):
+        self.__server._setup_ccsession()
+        self.__server._config_handler({}) # initial config load
+
+        # Similar to the previous test, but with transfer_acl config
+        self.__server._config_handler({'zone_config':
+                                       [{'origin': 'example.com',
+                                         'transfer_acl':
+                                         [{'from': '127.0.0.1',
+                                           'action': 'ACCEPT'}]}]})
+        acl = self.__server._zone_config[('IN', 'example.com.')]['transfer_acl']
+        self.__check_loaded_ACL(acl)
+
+        # invalid ACL syntax will be rejected with an error
+        ans = bundy.config.parse_answer(self.__server._config_handler(
+            {'zone_config': [{'origin': 'example.com',
+                              'transfer_acl': [{'action': 'BADACTION'}]}]}))
+        self.assertEqual(1, ans[0])
+
+    def test_get_db_file(self):
+        self.__server._setup_ccsession()
+        self.assertEqual(self.__server.get_db_file(), "initdb.file")
+
+    def test_increase_transfers_counter(self):
+        self.__server._max_transfers_out = 10
+        count = self.__server._transfers_counter
+        self.assertEqual(self.__server.increase_transfers_counter(), True)
+        self.assertEqual(count + 1, self.__server._transfers_counter)
+
+        self.__server._max_transfers_out = 0
+        count = self.__server._transfers_counter
+        self.assertEqual(self.__server.increase_transfers_counter(), False)
+        self.assertEqual(count, self.__server._transfers_counter)
+
+    def test_decrease_transfers_counter(self):
+        count = self.__server._transfers_counter
+        self.__server.decrease_transfers_counter()
+        self.assertEqual(count - 1, self.__server._transfers_counter)
+
+    def __remove_file(self, sock_file):
+        try:
+            os.remove(sock_file)
+        except OSError:
+            pass
+
+    def test_sock_file_in_use_file_exist(self):
+        self.__remove_file(self.__temp_sock_file)
+        self.assertFalse(self.__server._sock_file_in_use(self.__temp_sock_file))
+        self.assertFalse(os.path.exists(self.__temp_sock_file))
+
+    def test_sock_file_in_use_file_not_exist(self):
+        self.assertFalse(self.__server._sock_file_in_use(self.__temp_sock_file))
+
+    def test_sock_file_in_use(self):
+        self.__remove_file(self.__temp_sock_file)
+        self.assertFalse(self.__server._sock_file_in_use(self.__temp_sock_file))
+        self.__server._setup_listen_socket(self.__temp_sock_file)
+        self.assertTrue(self.__server._sock_file_in_use(self.__temp_sock_file))
+
+    def test_remove_unused_sock_file_in_use(self):
+        self.__remove_file(self.__temp_sock_file)
+        self.assertFalse(self.__server._sock_file_in_use(self.__temp_sock_file))
+        self.__server._setup_listen_socket(self.__temp_sock_file)
+        self.assertRaises(SystemExit, self.__server._remove_unused_sock_file,
+                          self.__temp_sock_file)
+
+    def test_remove_unused_sock_file_dir(self):
+        import tempfile
+        dir_name = tempfile.mkdtemp()
+        with open(os.devnull, 'w') as f:
+            sys.stdout = f
+            try:
+                self.__server._remove_unused_sock_file(dir_name)
+            except SystemExit:
+                pass
+            else:
+                # This should never happen
+                self.assertTrue(False)
+        os.rmdir(dir_name)
+
+    def test_accept_forwarder(self):
+        """ Test that we can accept a new connection.
+
+        (Largely copied from a similar test for ddns)
+
+        """
+        # There's nothing before the accept
+        xfrout.bundy.util.cio.socketsession.SocketSessionReceiver = \
+            FakeSessionReceiver
+        self.assertEqual({}, self.__server._socksession_receivers)
+        self.__server._listen_socket = FakeSocket(2)
+        self.__server._accept_forwarder()
+        # Now the new socket session receiver is stored in the dict
+        # The 3 comes from _listen_socket.accept() - _listen_socket has
+        # fileno 2 and accept returns socket with fileno increased by one.
+        self.assertEqual([3],
+                         list(self.__server._socksession_receivers.keys()))
+        (socket, receiver) = self.__server._socksession_receivers[3]
+        self.assertTrue(isinstance(socket, FakeSocket))
+        self.assertEqual(3, socket.fileno())
+        self.assertTrue(isinstance(receiver, FakeSessionReceiver))
+        self.assertEqual(socket, receiver.socket())
+
+        # check callback.  confirm it's registered and is a call to
+        # _handle_request.
+        cb = self.__server.rcallbacks[3]
+        self.__server._handle_request = lambda s: 42
+        self.assertEqual(42, cb())
+
+    def test_accept_forward_fail(self):
+        """
+        Test we don't crash if an accept fails and that we don't modify the
+        internals.  (Largely copied from a similar test for ddns)
+        """
+        # Make the accept fail
+        def accept_failure():
+            raise socket.error(errno.ECONNABORTED)
+        self.__server._listen_socket = FakeSocket(2)
+        orig = self.__server._listen_socket.accept
+        self.__server._listen_socket.accept = accept_failure
+        self.assertEqual({}, self.__server._socksession_receivers)
+        # Doesn't raise the exception
+        self.__server._accept_forwarder()
+        # And nothing is stored
+        self.assertEqual({}, self.__server._socksession_receivers)
+        # Now make the socket receiver fail
+        self.__server._listen_socket.accept = orig
+        def receiver_failure(sock):
+            raise bundy.util.cio.socketsession.SocketSessionError('Test error')
+        xfrout.bundy.util.cio.socketsession.SocketSessionReceiver = \
+            receiver_failure
+        # Doesn't raise the exception
+        self.__server._accept_forwarder()
+        # And nothing is stored
+        self.assertEqual({}, self.__server._socksession_receivers)
+        # Check we don't catch everything, so raise just an exception
+        def unexpected_failure(sock):
+            raise Exception('Test error')
+        xfrout.bundy.util.cio.socketsession.SocketSessionReceiver = \
+            unexpected_failure
+        # This one gets through
+        self.assertRaises(Exception, self.__server._accept_forwarder)
+        # Nothing is stored as well
+        self.assertEqual({}, self.__server._socksession_receivers)
+
+    def test_handle_request(self):
+        # Setup: mock some stuff used in _handle_request() so we can inspect
+        # and/or bypass the actual one for testing purposes.
+        sock = FakeSocket(3)
+        receiver = FakeSessionReceiver(sock)
+        popped_sock = FakeSocket(4)
+        param = (popped_sock, ('::1', 1234), ('::1', 1235),
+                 'Some data')
+        receiver.pop = lambda: param
+        self.__server._socksession_receivers = {3: (sock, receiver)}
+        xfrout.threading.Thread = FakeThread
+        def xfrout_session(*args):
+            self.__xfrout_session_args = args
+        xfrout.XfroutSession = xfrout_session
+
+        # Normal case: an XfroutSession instance is created with expected
+        # parameters.
+        self.__server._handle_request(3)
+        self.assertEqual((4, 'Some data', self.__server, 'test-ring',
+                          (socket.AF_INET6, socket.SOCK_STREAM, ('::1', 1235)),
+                          self.__server._acl, self.__server._zone_config,
+                          self.__server._counters),
+                         self.__xfrout_session_args)
+
+        # An unexpected case: a UDP session is forwarded.  It's just ignored.
+        # The forwarded socket should be closed.
+        popped_sock.proto = socket.IPPROTO_UDP
+        popped_sock.closed = False
+        self.__server._handle_request(3)
+        self.assertTrue(popped_sock.closed)
+        popped_sock.proto = socket.IPPROTO_TCP # reset the tweaked proto
+
+        # failure in the sock session receiver.  this receiver is terminated
+        # and removed from the watch list.
+        self.__xfrout_session_args = None
+        self.__server.rcallbacks[3] = None # None is fine, as callback is unused
+        def ex_raiser():
+            raise bundy.util.cio.socketsession.SocketSessionError('an error')
+        receiver.pop = ex_raiser
+        self.__server._handle_request(3)
+        self.assertFalse(3 in self.__server._socksession_receivers)
+        self.assertFalse(3 in self.__server.rcallbacks)
 
 if __name__== "__main__":
     bundy.log.resetUnitTestRootLogger()

--- a/src/bin/xfrout/xfrout.py.in
+++ b/src/bin/xfrout/xfrout.py.in
@@ -23,6 +23,8 @@ import threading
 import struct
 import signal
 from bundy.datasrc import DataSourceClient, ZoneFinder, ZoneJournalReader
+from bundy.server_common.bundy_server import BUNDYServer, BUNDYServerFatal
+import bundy.util.cio.socketsession
 from socketserver import *
 import os
 from bundy.config.ccsession import *
@@ -63,6 +65,11 @@ from bundy.acl.acl import ACCEPT, REJECT, DROP, LoaderError
 from bundy.acl.dns import REQUEST_LOADER
 
 bundy.util.process.rename()
+
+def _clear_socket():
+    """Common initialization/cleanup: remove the socket file, if it exists."""
+    if os.path.exists(UNIX_SOCKET_FILE):
+        os.remove(UNIX_SOCKET_FILE)
 
 class XfroutConfigError(Exception):
     """An exception indicating an error in updating xfrout configuration.
@@ -1020,8 +1027,14 @@ class XfroutServer:
         self._default_notify_port = 53
         self._unix_socket_server = None
         self._listen_sock_file = UNIX_SOCKET_FILE
+        _clear_socket()
+        self._listen_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._listen_socket.bind(UNIX_SOCKET_FILE)
+        self._listen_socket.listen(16)
         self._shutdown_event = threading.Event()
-        self._cc = bundy.config.ModuleCCSession(SPECFILE_LOCATION, self.config_handler, self.command_handler)
+        self._cc = bundy.config.ModuleCCSession(SPECFILE_LOCATION,
+                                                self.config_handler,
+                                                self.command_handler)
         self._config_data = self._cc.get_full_config()
         self._counters = Counters(SPECFILE_LOCATION)
         self._cc.start()
@@ -1146,6 +1159,353 @@ class XfroutServer:
         while not self._shutdown_event.is_set():
             self._cc.check_command(False)
 
+class NewXfroutServer(BUNDYServer):
+    """The top-level server class for Xfrout.
+
+    This class handles xfrout command and configuration updates, accepts
+    xfr queries through UNIX domain sockets, and manages sub threads that
+    actually handle the queries.
+
+    """
+    def __init__(self):
+        BUNDYServer.__init__(self)
+
+        self._default_notify_address = ''
+        self._default_notify_port = 53
+
+        self.__lock = threading.Lock() # private
+
+        # shared with child threads
+        self._shutdown_event = threading.Event()
+
+        # Rest of the "protected" attributes are essentially private, but
+        # we allow tests to inspect/tweat them.
+        self._transfers_counter = 0
+        self._config_data = None
+        self._zone_config = {}
+        self._acl = None # this will be initialized in update_config_data()
+        self._counters = Counters(SPECFILE_LOCATION)
+        self._notifier = None
+
+        # List of the session receivers where we get the requests
+        self._socksession_receivers = {}
+
+        self._setup_listen_socket(UNIX_SOCKET_FILE)
+
+    def _setup_listen_socket(self, sock_file):
+        """Set up a UNIX domain socket to receive forwarded xfr queries."""
+        self._remove_unused_sock_file(sock_file)
+        self._listen_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._listen_socket.bind(sock_file)
+        self._listen_socket.listen(16)
+        self._counters.inc('socket', 'unixdomain', 'open')
+        self.watch_fileno(self._listen_socket, self._accept_forwarder)
+
+    def _remove_unused_sock_file(self, sock_file):
+        """Try to remove the given socket file.
+
+        If the file is being used by one running xfrout process, exit from
+        python. If it's not a socket file or nobody is listening,
+        it will be removed. If it can't be removed, exit from python.
+
+        """
+        if self._sock_file_in_use(sock_file):
+            logger.error(XFROUT_UNIX_SOCKET_FILE_IN_USE, sock_file)
+            sys.exit(0)
+        else:
+            if not os.path.exists(sock_file):
+                return
+            try:
+                os.unlink(sock_file)
+            except OSError as err:
+                logger.error(XFROUT_REMOVE_OLD_UNIX_SOCKET_FILE_ERROR,
+                             sock_file, str(err))
+                sys.exit(0)
+
+    def _sock_file_in_use(self, sock_file):
+        """Check whether the socket file 'sock_file' exists and
+        is being used by one running xfrout process. If it is,
+        return True, or else return False.
+
+        """
+        sock = socket.socket(socket.AF_UNIX)
+        try:
+            sock.connect(sock_file)
+        except socket.error:
+            return False
+        else:
+            return True
+        finally:
+            sock.close()
+
+    def _setup_module(self):
+        """Override the BUNDYServer default.
+
+        Some of the setups in this method can fail, but we generally consider
+        it a fatal system error and let the process die.
+
+        """
+        self.mod_ccsession.add_remote_config(AUTH_SPECFILE_LOCATION)
+        bundy.server_common.tsig_keyring.init_keyring(self.mod_ccsession)
+        self.__start_notifier()
+        logger.debug(DBG_PROCESS, XFROUT_STARTED)
+
+    def __start_notifier(self):
+        """Subroutine of _setup_module, init and start NotifyOut thread."""
+        datasrc = self.get_db_file()
+        self._notifier = notify_out.NotifyOut(datasrc, counters=self._counters)
+        if 'also_notify' in self._config_data:
+            for slave in self._config_data['also_notify']:
+                address = self._default_notify_address
+                if 'address' in slave:
+                    address = slave['address']
+                port = self._default_notify_port
+                if 'port' in slave:
+                    port = slave['port']
+                self._notifier.add_slave(address, port)
+
+        # We'll make the notifier thread a daemon in case the main thread
+        # dies without a proper shutdown, in which case we'd rather like
+        # the notifier to die, too.
+        self._notifier.dispatcher(True)
+
+    def _shutdown_module(self):
+        """Override the BUNDYServer default.
+
+        We don't expect this method to raise an exception.  If it does,
+        that's basically a program error and make the process terminate
+        in a non-graceful manner.
+
+        """
+        self._listen_socket.close()
+        self._counters.inc('socket', 'unixdomain', 'close')
+        try:
+            os.unlink(UNIX_SOCKET_FILE)
+        except Exception as e:
+            logger.error(XFROUT_REMOVE_UNIX_SOCKET_FILE_ERROR, UNIX_SOCKET_FILE,
+                         e)
+        self._shutdown_event.set()
+        self._notifier.shutdown()
+        self._wait_for_threads()
+
+    def _wait_for_threads(self):
+        # Wait for all threads to terminate. this is a call that is only used
+        # in _shutdown_module(), but it has its own method, so we can test
+        # _shutdown_module() without involving thread operations (the test
+        # would override this method)
+        main_thread = threading.currentThread()
+        for th in threading.enumerate():
+            if th is main_thread:
+                continue
+            th.join()
+
+    def _mod_command_handler(self, cmd, args):
+        """Command handler: overriding the BUNDYServer default."""
+        if cmd == "notify":
+            zone_name = args.get('zone_name')
+            zone_class = args.get('zone_class')
+            if not zone_class:
+                zone_class = str(RRClass.IN)
+            if zone_name:
+                logger.info(XFROUT_NOTIFY_COMMAND, zone_name, zone_class)
+                if self._notifier.send_notify(zone_name, zone_class):
+                    answer = create_answer(0)
+                else:
+                    zonestr = notify_out.format_zone_str(Name(zone_name),
+                                                         zone_class)
+                    answer = create_answer(1, "Unknown zone: " + zonestr)
+            else:
+                answer = create_answer(1, "Bad command parameter: " + str(args))
+
+        # return statistics data to the stats daemon
+        elif cmd == "getstats":
+            # The log level is here set to debug in order to avoid
+            # that a log becomes too verbose. Because the bundy-stats
+            # daemon is periodically asking to the bundy-xfrout daemon.
+            answer = create_answer(0, self._counters.get_statistics())
+            logger.debug(DBG_XFROUT_TRACE, XFROUT_RECEIVED_GETSTATS_COMMAND,
+                         str(answer))
+        else:
+            answer = create_answer(1, "Unknown command:" + str(cmd))
+
+        return answer
+
+    def _config_handler(self, new_config):
+        """Config handler: a mandatory method to implement for BUNDYServer.
+
+        TODO. Do error check
+
+        """
+        answer = create_answer(0)
+        if self._config_data is None:
+            new_config = self.mod_ccsession.get_full_config()
+            self._config_data = new_config
+        else:
+            for key in new_config:
+                if key not in self._config_data:
+                    answer = create_answer(1, "Unknown config data: " +
+                                           str(key))
+                    continue
+                self._config_data[key] = new_config[key]
+        try:
+            self.__update_config_data(self._config_data)
+        except Exception as e:
+            answer = create_answer(1, "Failed to handle new configuration: " +
+                                   str(e))
+        return answer
+
+    def __update_config_data(self, new_config):
+        """Apply the new config setting of xfrout module."""
+        with self.__lock:
+            logger.info(XFROUT_NEW_CONFIG)
+            new_acl = self._acl
+            if 'transfer_acl' in new_config:
+                try:
+                    new_acl = REQUEST_LOADER.load(new_config['transfer_acl'])
+                except LoaderError as e:
+                    raise XfroutConfigError('Failed to parse transfer_acl: ' +
+                                            str(e))
+
+            new_zone_config = self._zone_config
+            zconfig_data = new_config.get('zone_config')
+            if zconfig_data is not None:
+                new_zone_config = self.__create_zone_config(zconfig_data)
+
+            self._acl = new_acl
+            self._zone_config = new_zone_config
+            self._max_transfers_out = new_config.get('transfers_out')
+        logger.info(XFROUT_NEW_CONFIG_DONE)
+
+    def __create_zone_config(self, zone_config_list):
+        new_config = {}
+        for zconf in zone_config_list:
+            # convert the class, origin (name) pair.  First build pydnspp
+            # object to reject invalid input.
+            zclass_str = zconf.get('class')
+            if zclass_str is None:
+                zclass_str = self.mod_ccsession.get_default_value(
+                    'zone_config/class')
+            zclass = RRClass(zclass_str)
+            zorigin = Name(zconf['origin'], True)
+            config_key = (zclass.to_text(), zorigin.to_text())
+
+            # reject duplicate config
+            if config_key in new_config:
+                raise XfroutConfigError('Duplicate zone_config for ' +
+                                        str(zorigin) + '/' + str(zclass))
+
+            # create a new config entry, build any given (and known) config
+            new_config[config_key] = {}
+            if 'transfer_acl' in zconf:
+                try:
+                    new_config[config_key]['transfer_acl'] = \
+                        REQUEST_LOADER.load(zconf['transfer_acl'])
+                except LoaderError as e:
+                    raise XfroutConfigError('Failed to parse transfer_acl ' +
+                                            'for ' + zorigin.to_text() + '/' +
+                                            zclass_str + ': ' + str(e))
+        return new_config
+
+    def get_db_file(self):
+        file, is_default = self.mod_ccsession.get_remote_config_value(
+            "Auth", "database_file")
+        # this too should be unnecessary, but currently the
+        # 'from build' override isn't stored in the config
+        # (and we don't have indirect python access to datasources yet)
+        if is_default and "BUNDY_FROM_BUILD" in os.environ:
+            file = os.environ["BUNDY_FROM_BUILD"] + os.sep + \
+                   "bundy_zones.sqlite3"
+        return file
+
+    def increase_transfers_counter(self):
+        """Return if an incoming xfr query can be handled in terms of quota."""
+        ret = False
+        with self.__lock:
+            if self._transfers_counter < self._max_transfers_out:
+                self._transfers_counter += 1
+                ret = True
+        return ret
+
+    def decrease_transfers_counter(self):
+        """Called on completion of xfr query, release corresponding quota."""
+        with self.__lock:
+            self._transfers_counter -= 1
+
+    def _accept_forwarder(self):
+        """Accept a new socket session forwarder on the UNIX domain socket."""
+        try:
+            (sock, remote_addr) = self._listen_socket.accept()
+            fileno = sock.fileno()
+            logger.debug(DBG_XFROUT_TRACE, XFROUT_NEW_FORWARDER, fileno,
+                         remote_addr if remote_addr else '<anonymous address>')
+            receiver = bundy.util.cio.socketsession.SocketSessionReceiver(sock)
+            self._socksession_receivers[fileno] = (sock, receiver)
+            self.watch_fileno(fileno, lambda: self._handle_request(fileno))
+            self._counters.inc('socket', 'unixdomain', 'accept')
+        except (socket.error, bundy.util.cio.socketsession.SocketSessionError) \
+            as e:
+            # These exceptions mean the connection didn't work, but we can
+            # continue with the rest
+            logger.error(XFROUT_ACCEPT_FAILURE, e)
+            self._counters.inc('socket', 'unixdomain', 'acceptfail')
+
+    def _handle_request(self, fileno):
+        """Callback on a sock session receiver for a new xfr query."""
+        logger.debug(DBG_XFROUT_TRACE, XFROUT_REQUEST, fileno)
+
+        # In the context, if we are here we should have a receiver for
+        # 'fileno', so this code shouldn't fail:
+        (session_socket, receiver) = self._socksession_receivers[fileno]
+
+        try:
+            req_session = receiver.pop()
+        except bundy.util.cio.socketsession.SocketSessionError as se:
+            # No matter why this failed, the connection is in unknown, possibly
+            # broken state. So, we close the socket and remove the receiver.
+            del self._socksession_receivers[fileno]
+            session_socket.close()
+            self.unwatch_fileno(fileno, True, False, False)
+            logger.warn(XFROUT_DROP_FORWARDER, fileno, se)
+            self._counters.inc('socket', 'unixdomain', 'recverr')
+            return
+
+        try:
+            # The forwarder side should have filtered out non-TCP session,
+            # so this should be basically impossible.
+            if req_session[0].proto != socket.IPPROTO_TCP:
+                raise XfroutSessionError('unexpected session protocol: %d' %
+                                         req_session[0].proto)
+            (sock, local_addr, remote_addr, req_data) = req_session
+
+            # We basically don't expect an exception in the following, but
+            # since we perform some low-level system operation we catch any
+            # unexpected failures.
+
+            # Start a thread that handles the xfr query.  We'll make it as
+            # a daemon thread so if the main thread dies unexpectedly the
+            # child thread will be automatically killed.
+            th = threading.Thread(target=self.__start_session,
+                                  args=(sock, req_data, remote_addr))
+            th.daemon = True
+            th.start()
+        except Exception as ex:
+            req_session[0].close()
+            logger.error(XFROUT_REQUEST_FAIL, ex)
+
+    def __start_session(self, sock, req_data, remote_addr):
+        """Entry point of xfrout session threads."""
+        with self.__lock:
+            acl = self._acl
+            zone_config = self._zone_config
+        remote = (sock.family, sock.type, remote_addr)
+
+        # XfroutSession is basically exception free, and takes care of any
+        # cleanup on failure, so we just construct it.  The constructor will
+        # complete the request.
+        XfroutSession(sock.fileno(), req_data, self,
+                      bundy.server_common.tsig_keyring.get_keyring(),
+                      remote, acl, zone_config, self._counters)
+
 xfrout_server = None
 
 def signal_handler(signal, frame):
@@ -1189,5 +1549,11 @@ def main():
 
     logger.info(XFROUT_EXITING)
 
+def new_main():
+    xfrout = NewXfroutServer()
+    sys.exit(xfrout.run('xfrout'))
+
 if '__main__' == __name__:
+    #notyet:
+    #bundy.util.traceback_handler.traceback_handler(new_main)
     bundy.util.traceback_handler.traceback_handler(main)

--- a/src/bin/xfrout/xfrout_messages.mes
+++ b/src/bin/xfrout/xfrout_messages.mes
@@ -15,6 +15,12 @@
 # No namespace declaration - these constants go in the global namespace
 # of the xfrout messages python module.
 
+% XFROUT_ACCEPT_FAILURE error accepting a forwarder connection: %1
+There was a low-level error when Xfrout tried to accept an incoming connection
+(probably coming from bundy-auth). It continues serving on whatever other
+connections it already has, but this connection is dropped. The reason
+is logged.
+
 % XFROUT_BAD_TSIG_KEY_STRING bad TSIG key string: %1
 The TSIG key string as read from the configuration does not represent
 a valid TSIG key.
@@ -31,6 +37,13 @@ configuration manager bundy-cfgmgr is not running.
 % XFROUT_CONFIG_ERROR error found in configuration data: %1
 The xfrout process encountered an error when installing the configuration at
 startup time.  Details of the error are included in the log message.
+
+% XFROUT_DROP_FORWARDER dropping forwarder connection on file descriptor %1: %2
+There was an error on a connection with the bundy-auth server (or whatever
+connects to the Xfrout daemon). This might be OK, for example when the
+authoritative server shuts down, the connection would get closed. It also
+can mean the system is busy and can't keep up or that the other side got
+confused and sent bad data.
 
 % XFROUT_EXITING exiting
 The xfrout daemon is exiting.
@@ -102,6 +115,12 @@ manager. The xfrout daemon will now apply them.
 % XFROUT_NEW_CONFIG_DONE Update xfrout configuration done
 The xfrout daemon is now done reading the new configuration settings
 received from the configuration manager.
+
+% XFROUT_NEW_FORWARDER new xfr forwarder on file descriptor %1 from %2
+Debug message. Xfrout received a connection and it's going to start handling
+requests from it. The file descriptor number and the address where the request
+comes from is logged. The connection is over a unix domain socket and is likely
+coming from a bundy-auth process.
 
 % XFROUT_NOTIFY_COMMAND received command to send notifies for %1/%2
 The xfrout daemon received a command on the command channel that
@@ -179,6 +198,17 @@ daemon will shut down.
 When shutting down, the xfrout daemon tried to clear the unix socket
 file used for communication with the auth daemon. It failed to remove
 the file. The reason for the failure is given in the error message.
+
+% XFROUT_REQUEST xfr request session arrived on file descriptor %1
+A debug message, informing there's some activity on the given file descriptor.
+It will be either a request or the file descriptor will be closed. See
+following log messages to see what of it.
+
+% XFROUT_REQUEST_FAIL failed to handle forwarded xfr query: %1
+The Xfrout daemon has received a new xfr query and tried to start an
+internal session for it, but it failed in an unexpected way.  The Xfrout
+daemon still keeps running and handling subsequent queries, but it's
+advisable to check the cause of the failure.
 
 % XFROUT_SOCKET_SELECT_ERROR error while calling select() on request socket: %1
 There was an error while calling select() on the socket that informs


### PR DESCRIPTION
It also uses the generic socketsession module to get xfr queries from
bundy-auth.  this will eliminate the need for the in-house and yet incomplete
support of query forwarding.

a new tentative class NewXfroutServer is introduced to add the implementation
and unit tests until the auth side is updated (it's currently only used for
tests).  

Although the size of the diff is large, this is mostly a copy + adjustment of the original xfrout and
UnixSockServer classes, and of bundy-memmgr (which uses BUNDYServer), so this should be
a relatively low-risk change.  I hope someone can take a look at it for sanity check.  Otherwise
I'll merge it at my own discretion some time later.
