### PR TITLE
Shmem3: extend memmgr so it validates mapped files on startup

### DIFF
--- a/src/bin/memmgr/memmgr.py.in
+++ b/src/bin/memmgr/memmgr.py.in
@@ -238,23 +238,22 @@ class Memmgr(BUNDYServer):
             self._builder_cv.notify_all()
 
     def __notify_readers(self, rrclass, dsrc_name, sgmt_info, readers,
-                         skip_ok=False):
+                         inuse_only=False):
         """Helper to form and send segment_info_update message to readers.
 
-        Unless 'skip_ok' is explicitly set to True a segment for readers
-        must be available.
+        If 'inuse_only' is True, tell the readers to reset the segment
+        only if they are currently using another segment.
 
         """
 
         reset_param = sgmt_info.get_reset_param(SegmentInfo.READER)
-        if reset_param is None:
-            assert(skip_ok)
-            return
         params = {
             'data-source-class': str(rrclass),
             'data-source-name': dsrc_name,
             'segment-params': reset_param
         }
+        if inuse_only:
+            params['inuse-only'] = True
         for reader in readers:
             params['reader'] = reader
             rcmd = bundy.config.create_command('segment_info_update', params)
@@ -280,25 +279,36 @@ class Memmgr(BUNDYServer):
             del self._builder_response_queue[:]
         for notification in notifications:
             notif_name = notification[0]
-            if notif_name == 'load-completed':
-                (_, dsrc_info, rrclass, dsrc_name) = notification
+            if notif_name in ('validate-completed', 'load-completed'):
+                (_, dsrc_info, rrclass, dsrc_name, result) = notification
                 sgmt_info = dsrc_info.segment_info_map[(rrclass, dsrc_name)]
-                cmd = sgmt_info.complete_update()
-                # It may return another load command on the same data source.
+                if notif_name == 'validate-completed':
+                    cmd = sgmt_info.complete_validate(result)
+                else:
+                    cmd = sgmt_info.complete_update()
+
+                # It may return another builder command on the same data source.
                 # If it is so, we execute it too, before we start
                 # synchronizing with the readers.
                 if cmd is not None:
                     self._cmd_to_builder(cmd)
 
                 # If there are readers of the old version of this segment,
-                # notify them so they'll move to the newly loaded version.
+                # notify them so they'll move to the new version of segment.
+                # If this is on completion of validation, we'll only have them
+                # actually reset the segment when they are currently using
+                # another one, just so the memmgr can safely update the 'writer'
+                # version of the segment; otherwise we'd rather tell them to
+                # switch when the latest data are loaded.
                 old_readers = sgmt_info.get_old_readers()
+                inuse_only = (notif_name == 'validate-completed')
                 if old_readers:
                     self.__notify_readers(rrclass, dsrc_name, sgmt_info,
-                                          old_readers)
-                logger.debug(logger.DBGLVL_TRACE_BASIC, MEMMGR_LOAD_COMPLETED,
-                             dsrc_name, rrclass,
-                             'without' if cmd is None else 'with',
+                                          old_readers, inuse_only=inuse_only)
+                logger.debug(logger.DBGLVL_TRACE_BASIC,
+                             MEMMGR_COMMAND_COMPLETED,
+                             notif_name.replace('-completed', ''), dsrc_name,
+                             rrclass, 'without' if cmd is None else 'with',
                              len(old_readers))
             else:
                 raise ValueError('Unknown notification name: ' + notif_name)
@@ -390,12 +400,12 @@ class Memmgr(BUNDYServer):
                 for dsrc_info in self._datasrc_info_list:
                     for key, sgmt_info in dsrc_info.segment_info_map.items():
                         sgmt_info.add_reader(reader)
-                        rrclass, dsrc_name = key
-                        # If a reader segment is ready, we should tell the
-                        # reader about it.  It's possible a readable segment
-                        # isn't ready yet, so set skip_ok to True.
-                        self.__notify_readers(rrclass, dsrc_name, sgmt_info,
-                                              [reader], skip_ok=True)
+                        # If a reader segment has been loaded, we should tell
+                        # the reader about it.
+                        if sgmt_info.loaded():
+                            rrclass, dsrc_name = key
+                            self.__notify_readers(rrclass, dsrc_name, sgmt_info,
+                                                  [reader])
         else:                   # must be 'unsubscribed'
             if not reader in self._segment_readers:
                 logger.warn(MEMMGR_CCMEMBER_DUP_UNSUBSCRIBED, reader)
@@ -477,14 +487,24 @@ class Memmgr(BUNDYServer):
     def _init_segments(self, datasrc_info):
         for key, sgmt_info in datasrc_info.segment_info_map.items():
             rrclass, dsrc_name = key
-            cmd = ('load', None, datasrc_info, rrclass, dsrc_name)
+
             for reader in self._segment_readers.keys():
                 sgmt_info.add_reader(reader)
-            sgmt_info.add_event(cmd)
-            send_cmd = sgmt_info.start_update()
-            assert cmd == send_cmd and sgmt_info.get_state() == \
-                SegmentInfo.UPDATING
+
+            # Initiate validating memory segments, send command for the reader
+            # segment to the builder
+            rvalidate_arg, wvalidate_arg = sgmt_info.start_validate()
+            cmd = ('validate', datasrc_info, rrclass, dsrc_name, rvalidate_arg)
             self._cmd_to_builder(cmd)
+
+            # Schedule additional initial commands: validating the writer
+            # segment, followed by the initial full load.
+            cmd = ('validate', datasrc_info, rrclass, dsrc_name, wvalidate_arg)
+            sgmt_info.add_event(cmd)
+            cmd = ('load', None, datasrc_info, rrclass, dsrc_name)
+            sgmt_info.add_event(cmd)
+
+            assert sgmt_info.get_state() == SegmentInfo.R_VALIDATING
 
 def main():
     mgr = Memmgr()

--- a/src/bin/memmgr/memmgr_messages.mes
+++ b/src/bin/memmgr/memmgr_messages.mes
@@ -87,12 +87,12 @@ for a zone from other module.
 % MEMMGR_LOADZONE_FAIL failed to handle command: %1
 Error happend in handling the zoneload command.
 
-% MEMMGR_LOAD_COMPLETED load completed for '%1/%2', %3 new load command, %4 readers notified
+% MEMMGR_COMMAND_COMPLETED %1 command completed for '%2/%3', %4 more command, %5 readers notified
 An informational message.  The memmgr was notified from a helper
-thread of the completion of loading zone data.  The corresponding data
-source and RR class names are shown.  It also shows whether a new load
-command was immediately sent to the thread, and how many segment
-readers were notified.
+thread of the completion of validating or loading zone data.  The
+corresponding data source and RR class names are shown.  It also shows
+whether a new command was immediately sent to the thread, and how many
+segment readers were notified.
 
 % MEMMGR_NO_DATASRC_CONF failed to add data source configuration: %1
 The memmgr daemon tried to incorporate data source configuration on

--- a/src/lib/python/bundy/memmgr/builder.py
+++ b/src/lib/python/bundy/memmgr/builder.py
@@ -26,6 +26,11 @@ class MemorySegmentBuilder:
     in the given order sequentially.
     """
 
+    # Internal return code for __reset_segment()
+    __RESET_SEGMENT_OK = 0
+    __RESET_SEGMENT_FAILED = 1
+    __RESET_SEGMENT_CREATED = 2
+
     def __init__(self, sock, cv, command_queue, response_queue):
         """ The constructor takes the following arguments:
 
@@ -73,7 +78,54 @@ class MemorySegmentBuilder:
         self._response_queue.append(('bad_command',))
         self._shutdown = True
 
-    def __handle_load(self, zone_name, dsrc_info, rrclass, dsrc_name):
+    def __handle_validate(self, args):
+        """Handle 'validate' command.
+
+        Command arguments are the same 'load' except the last one:
+        'action': callable without any parameter itself, encapsulating
+                  any segment-specific validation logic.  It returns
+                  a result of the validation.
+
+        This method simply calls the passed action, and returns the result
+        back to the memmgr with other command arguments.  This is run in
+        the builder thread simply because it may take time.
+
+        """
+        _, dsrc_info, rrclass, dsrc_name, action = args
+
+        logger.debug(logger.DBGLVL_TRACE_BASIC,
+                     LIBMEMMGR_BUILDER_SEGMENT_VALIDATE, dsrc_name, rrclass)
+        try:
+            result = action()
+        except Exception as ex:
+            logger.error(LIBMEMMGR_BUILDER_SEGMENT_VALIDATE_FAIL, dsrc_name,
+                         rrclass, ex)
+            result = False
+        self._response_queue.append(('validate-completed', dsrc_info, rrclass,
+                                     dsrc_name, result))
+
+    def __reset_segment(self, clist, dsrc_name, rrclass, params):
+        try:
+            clist.reset_memory_segment(dsrc_name,
+                                       ConfigurableClientList.READ_WRITE,
+                                       params)
+            logger.debug(logger.DBGLVL_TRACE_BASIC,
+                         LIBMEMMGR_BUILDER_SEGMENT_RESET, dsrc_name, rrclass)
+            return self.__RESET_SEGMENT_OK
+        except Exception as ex:
+            logger.error(LIBMEMMGR_BUILDER_RESET_SEGMENT_ERROR, dsrc_name,
+                         rrclass, ex)
+        try:
+            clist.reset_memory_segment(dsrc_name, ConfigurableClientList.CREATE,
+                                       params)
+            logger.info(LIBMEMMGR_BUILDER_SEGMENT_CREATED, dsrc_name, rrclass)
+            return self.__RESET_SEGMENT_CREATED
+        except Exception as ex:
+            logger.error(LIBMEMMGR_BUILDER_SEGMENT_CREATE_ERROR, dsrc_name,
+                         rrclass, ex)
+        return self.__RESET_SEGMENT_FAILED
+
+    def _handle_load(self, zone_name, dsrc_info, rrclass, dsrc_name):
         # This method is called when handling the 'load' command. The
         # following tuple is passed:
         #
@@ -92,49 +144,64 @@ class MemorySegmentBuilder:
         #    data source.
         #
         #  * dsrc_name is a string, specifying a data source name.
+        #
+        # This is essentially a 'private' method, but allows tests to call it
+        # directly; for other purposes shouldn't be called outside of the class.
 
         clist = dsrc_info.clients_map[rrclass]
         sgmt_info = dsrc_info.segment_info_map[(rrclass, dsrc_name)]
         params = json.dumps(sgmt_info.get_reset_param(SegmentInfo.WRITER))
-        clist.reset_memory_segment(dsrc_name,
-                                   ConfigurableClientList.READ_WRITE,
-                                   params)
-        logger.debug(logger.DBGLVL_TRACE_BASIC, LIBMEMMGR_BUILDER_SEGMENT_OPEND,
-                     dsrc_name, rrclass)
+        result = self.__reset_segment(clist, dsrc_name, rrclass, params)
+        if result == self.__RESET_SEGMENT_FAILED:
+            self._response_queue.append(('load-completed', dsrc_info, rrclass,
+                                         dsrc_name, False))
+            return
 
+        # If we were told to load a single zone but had to create a new
+        # segment, we'll need to all zones, not this one.
+        if result == self.__RESET_SEGMENT_CREATED and zone_name is not None:
+            logger.info(LIBMEMMGR_BUILDER_SEGMENT_LOAD_ALL, zone_name, rrclass,
+                        dsrc_name)
+            zone_name = None
         if zone_name is not None:
             zones = [(None, zone_name)]
         else:
             zones = clist.get_zone_table_accessor(dsrc_name, True)
 
         for _, zone_name in zones:
-            catch_load_error = (zone_name is None) # install empty zone initially
-            result, writer = clist.get_cached_zone_writer(zone_name, catch_load_error,
+            # install empty zone initially
+            catch_load_error = (zone_name is None)
+            result, writer = clist.get_cached_zone_writer(zone_name,
+                                                          catch_load_error,
                                                           dsrc_name)
             if result != ConfigurableClientList.CACHE_STATUS_ZONE_SUCCESS:
-                logger.error(LIBMEMMGR_BUILDER_GET_ZONE_WRITER_ERROR, zone_name, dsrc_name)
+                logger.error(LIBMEMMGR_BUILDER_GET_ZONE_WRITER_ERROR,
+                             zone_name, dsrc_name)
                 continue
 
             try:
                 error = writer.load()
                 if error is not None:
-                    logger.error(LIBMEMMGR_BUILDER_ZONE_WRITER_LOAD_1_ERROR, zone_name, dsrc_name, error)
+                    logger.error(LIBMEMMGR_BUILDER_ZONE_WRITER_LOAD_1_ERROR,
+                                 zone_name, dsrc_name, error)
                     continue
             except Exception as e:
-                logger.error(LIBMEMMGR_BUILDER_ZONE_WRITER_LOAD_2_ERROR, zone_name, dsrc_name, str(e))
+                logger.error(LIBMEMMGR_BUILDER_ZONE_WRITER_LOAD_2_ERROR,
+                             zone_name, dsrc_name, str(e))
                 continue
             writer.install()
             writer.cleanup()
 
         # need to reset the segment so readers can read it (note: memmgr
         # itself doesn't have to keep it open, but there's currently no
-        # public API to just clear the segment)
+        # public API to just clear the segment).  This 'reset' should succeed,
+        # so we'll let any exception be propagated.
         clist.reset_memory_segment(dsrc_name,
                                    ConfigurableClientList.READ_ONLY,
                                    params)
 
         self._response_queue.append(('load-completed', dsrc_info, rrclass,
-                                     dsrc_name))
+                                     dsrc_name, True))
 
     def run(self):
         """ This is the method invoked when the builder thread is
@@ -164,12 +231,16 @@ class MemorySegmentBuilder:
                     command = command_tuple[0]
                     logger.debug(logger.DBGLVL_TRACE_BASIC,
                                  LIBMEMMGR_BUILDER_RECEIVED_COMMAND, command)
-                    if command == 'load':
-                        # See the comments for __handle_load() for
+                    if command == 'validate':
+                        self.__handle_validate(command_tuple)
+                    elif command == 'load':
+                        # See the comments for _handle_load() for
                         # details of the tuple passed to the "load"
                         # command.
-                        _, zone_name, dsrc_info, rrclass, dsrc_name = command_tuple
-                        self.__handle_load(zone_name, dsrc_info, rrclass, dsrc_name)
+                        _, zone_name, dsrc_info, rrclass, dsrc_name = \
+                            command_tuple
+                        self._handle_load(zone_name, dsrc_info, rrclass,
+                                          dsrc_name)
                     elif command == 'shutdown':
                         self.__handle_shutdown()
                         # When the shutdown command is received, we do

--- a/src/lib/python/bundy/memmgr/datasrc_info.py
+++ b/src/lib/python/bundy/memmgr/datasrc_info.py
@@ -13,8 +13,11 @@
 # NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
 # WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import json
 import os
 from collections import deque
+from bundy.log_messages.libmemmgr_messages import *
+from bundy.memmgr.logger import logger
 
 class SegmentInfoError(Exception):
     """An exception raised for general errors in the SegmentInfo class."""
@@ -36,15 +39,36 @@ class SegmentInfo:
 
     A summarized (and simplified) state transition diagram (for __state)
     would be as follows:
-                                                +--sync_reader()/remove_reader()
-                                                |  still have old readers
-                                                |          |
-                UPDATING-----complete_--->SYNCHRONIZING<---+
+
+          INIT-----start_------->R_VALIDATING
+                validate()           |
+                             complete_validate()
+                                     |
+   W_VALIDATING<-----------V_SYNCHRONIZING----sync_reader()/remove_reader()
+           |   (no more reader)          ^    still have old readers
+           |                             +--------+
+        complete_
+       validate()                               +--sync_reader()/remove_reader()
+           |                                    |          |
+           |                                    |          |
+           +--> UPDATING-----complete_--->SYNCHRONIZING<---+
                   ^          update()           |
     start_update()|                             | sync_reader()/remove_reader()
     events        |                             V no more old reader
     exist       READY<------complete_----------COPYING
                             update()
+
+    A segment always begins with the 'INIT' stage, and completes validating
+    segments for readers and the writer.  This phase is intended to be used
+    to perform some initial validation on the segments before actually
+    using them (e.g., some segment implementation may check data integrity),
+    but details are up to the specific segment implementation and can even be
+    no-op.  This phase is also intended to be used to be synchronized
+    with existing readers that may be using segments in case memmgr has
+    restarted.  At the completion of the V_SYNCHRONIZING state, the memmgr
+    can be sure that no reader is using the writer version of the segment.
+    On the completion of W_VALIDATING, the segment is in use, and will
+    run normal cylce of updating.
 
     """
     # Common constants of user type: reader or writer
@@ -52,22 +76,29 @@ class SegmentInfo:
     WRITER = 1
 
     # Enumerated values for state:
-    UPDATING = 0 # the segment is being updated (by the builder thread,
+    INIT = -1 # Placeholdr for the initial state, immediatelly move to
+              # R_VALIDATING
+    R_VALIDATING = 0 # The segment for readers is being verified.
+    V_SYNCHRONIZING = 1 # similar to SYNCHRONIZING below, but used for
+                        # the transition from R_VALIDATING to W_VALIDATING.
+    W_VALIDATING = 2 # The segment for the writer (memmgr) is being verified.
+                     # Once this is completed, the segments are ready for use.
+    UPDATING = 3 # the segment is being updated (by the builder thread,
                  # although SegmentInfo won't care about this level of
                  # details).
-    SYNCHRONIZING = 1 # one pair of underlying segments has been
+    SYNCHRONIZING = 4 # one pair of underlying segments has been
                       # updated, and readers are now migrating to the
                       # updated version of the segment.
-    COPYING = 2 # all readers that used the old version of segment have
+    COPYING = 5 # all readers that used the old version of segment have
                 # been migrated to the updated version, and the old
                 # segment is now being updated.
-    READY = 3 # both segments of the pair have been updated. it can now
+    READY = 6 # both segments of the pair have been updated. it can now
               # handle further updates (e.g., from xfrin).
 
     def __init__(self):
         # Holds the state of SegmentInfo. See the class description
         # above for the state transition diagram.
-        self.__state = self.READY
+        self.__state = self.INIT
         # __readers is a set of 'reader_session_id' private to
         # SegmentInfo. It consists of the (ID of) reader modules that
         # are using the "current" reader version of the segment.
@@ -85,10 +116,12 @@ class SegmentInfo:
         # they arrived. SegmentInfo doesn't have to know the details of
         # the stored data; it only matters for the memmgr.
         self.__events = deque()
+        # See loaded():
+        self.__loaded = False
 
     def get_state(self):
-        """Returns the state of SegmentInfo (UPDATING, SYNCHRONIZING,
-        COPYING or READY)."""
+        """Returns the state of SegmentInfo (UPDATING, SYNCHRONIZING, etc)"""
+
         return self.__state
 
     def get_readers(self):
@@ -107,11 +140,14 @@ class SegmentInfo:
         """Returns a list of pending events in the order they arrived."""
         return list(self.__events)
 
-    # Helper method used in complete_update(), sync_reader() and
+    # Helper method used in complete_validate/update(), sync_reader() and
     # remove_reader().
     def __sync_reader_helper(self):
         if not self.__old_readers:
-            self.__state = self.COPYING
+            if self.__state is self.SYNCHRONIZING:
+                self.__state = self.COPYING
+            else:
+                self.__state = self.W_VALIDATING
             if self.__events:
                 return self.__events.popleft()
 
@@ -141,10 +177,78 @@ class SegmentInfo:
         the main thread itself (which also handles communications) and
         only have the builder in a different thread."""
         if reader_session_id in self.__readers:
-            raise SegmentInfoError('Reader session ID is already in readers set: ' +
-                                   str(reader_session_id))
+            raise SegmentInfoError('Reader session ID is already in readers ' +
+                                   'set: ' + str(reader_session_id))
 
         self.__readers.add(reader_session_id)
+
+    def start_validate(self):
+        """Start validation of memory segments.
+
+        The use of SegmentInfo always begins with this method.  It initiates
+        the state transition from INIT to R_VALIDATING.
+
+        It returns 2 callable objects in a tuple: 1st is to be used to
+        validate the reader segment; 2nd is to be used to validate the writer
+        segment.  The caller is expected to pass these to the builder thread
+        and evaluate them as the initial two commands for the segment.
+        The specific details of how the callable works depends on the
+        specific subclass of SegmentInfo, and the returned callables
+        are given from the _start_validate() "protected" method (each
+        subclass must implement that method).  In general, it is advisable
+        that the callable does not share any state of this object, since
+        it's evaluated in a separate thread and there can be a race condition
+        if it refers to a shared state.
+
+        """
+        if self.__state != self.INIT:
+            raise SegmentInfoError('start_validate can only be called once, ' +
+                                   'initially')
+        self.__state = self.R_VALIDATING
+        return self._start_validate()
+
+    def complete_validate(self, validated):
+        """Update status of a segment info on completion of a validate command.
+
+        This method is expected to be called when the validation command
+        is comleted by the builder thread and the main thread is notified
+        of the result.  The notification should include the result of
+        validation, and it's passed to this method.
+
+        This method changes the state from R_VALIDATING and V_SYNCHRONIZING,
+        and W_VALIDATING to UPDATING.  In both cases, there should be
+        an outstanding event for the builder thread, and it's returned to
+        the caller.
+
+        A subclass can add its specific handling in the _complete_validate()
+        'protected' method.
+
+        Parameter:
+        - validated (bool): True if validation succeeded; False otherwise.
+
+        """
+        self._complete_validate(validated)
+        if self.__state == self.R_VALIDATING:
+            self.__state = self.V_SYNCHRONIZING
+            self.__old_readers = self.__readers
+            self.__readers = set()
+            return self.__sync_reader_helper()
+        elif self.__state == self.W_VALIDATING:
+            self.__state = self.UPDATING
+            # There should be a command for the initial load.  We shouldn't
+            # pop it yet.
+            return self.__events[0]
+        else:                   # buggy case
+            raise SegmentInfoError('complete_validate() called in ' +
+                                   'incorrect state: ' + str(self.__state))
+
+    def _complete_validate(self, validated):
+        """A subslass specific processing of complete_validate.
+
+        A specific can override this method; by default it does nothing.
+
+        """
+        return
 
     def start_update(self):
         """If the current state is READY and there are pending events,
@@ -172,7 +276,13 @@ class SegmentInfo:
         readers using the "old" version of segment, it pops the head
         (oldest) event from the pending events queue and returns it. It
         is an error if this method is called in other states than
-        UPDATING and COPYING."""
+        UPDATING and COPYING.
+
+        """
+        # If this method is called, it means at least one load attempt is
+        # completed.
+        self.__loaded = True
+
         if self.__state == self.UPDATING:
             self._switch_versions()
             self.__state = self.SYNCHRONIZING
@@ -185,6 +295,16 @@ class SegmentInfo:
         else:
             raise SegmentInfoError('complete_update() called in ' +
                                    'incorrect state: ' + str(self.__state))
+
+    def loaded(self):
+        """Return true iff at least one load attempt has been completed.
+
+        This returns True even if the load attempt failed; the main purpose
+        is to tell the caller that the available segment has not just been
+        validated, but also is the latest.
+
+        """
+        return self.__loaded
 
     def sync_reader(self, reader_session_id):
         """Synchronize segment info with a reader.
@@ -207,7 +327,7 @@ class SegmentInfo:
         to care about the differences based on the internal state.
 
         """
-        if self.__state != self.SYNCHRONIZING:
+        if self.__state not in (self.V_SYNCHRONIZING, self.SYNCHRONIZING):
             return None
 
         if reader_session_id not in self.__old_readers:
@@ -238,7 +358,7 @@ class SegmentInfo:
 
         """
         if reader_session_id in self.__old_readers:
-            assert(self.__state == self.SYNCHRONIZING)
+            assert(self.__state in (self.V_SYNCHRONIZING, self.SYNCHRONIZING))
             self.__old_readers.remove(reader_session_id)
             return self.__sync_reader_helper()
         elif reader_session_id in self.__readers:
@@ -321,6 +441,18 @@ class SegmentInfo:
         """
         raise SegmentInfoError('_switch_versions is not implemented')
 
+def _validate_mapped_segment_file(filename):
+    """Callable used by MappedSegmentInfo, validating a mapped segment file.
+
+    In this initial version, we just check the existence of the file.
+
+    """
+    validated = filename is not None and os.path.exists(filename)
+    logger.info(LIBMEMMGR_MAPPED_SEGMENT_VALIDATE,
+                filename if filename is not None else '<unknown>',
+                'ok' if validated else 'failed')
+    return validated
+
 class MappedSegmentInfo(SegmentInfo):
     """SegmentInfo implementation of 'mapped' type memory segments.
 
@@ -344,28 +476,92 @@ class MappedSegmentInfo(SegmentInfo):
         # writer.  In this initial implementation we assume that all possible
         # readers are waiting for a new version (not using pre-existing one),
         # and the writer is expected to build a new segment as version "0".
-        self.__reader_ver = None # => 0 => 1 => 0 => 1 ...
-        self.__writer_ver = 0    # => 1 => 0 => 1 => 0 ...
+        self.__reader_ver = None
+        self.__writer_ver = None
 
-    def get_reset_param(self, user_type):
-        ver = self.__reader_ver if user_type == self.READER else \
-            self.__writer_ver
-        if ver is None:
-            return None
+        # State of mapped file for readers: becomes true if validated
+        # successfully or switched from successfully updated writer version.
+        # Unless it's true, we won't tell readers the mapped file as it won't
+        # be usable. For writer (which is actually the memmgr itself, in
+        # practice), we'll always try to open/create it for any update attempt.
+        self.__reader_file_validated = False
+
+        self.__map_versions_file = self.__mapped_file_base + '-vers.json'
+        if os.path.exists(self.__map_versions_file):
+            try:
+                with open(self.__map_versions_file) as f:
+                    versions = json.load(f)
+
+                # reset both versions at once; if either of the values is
+                # unavailable, neither variables will be reset.
+                rver, wver = versions['reader'], versions['writer']
+                if not ((rver == 0 and wver == 1) or (rver == 1 and wver == 0)):
+                    raise SegmentInfoError('broken segment version')
+                self.__reader_ver = rver
+                self.__writer_ver = wver
+            except Exception as ex:
+                # This is somewhat unexpected, but not fatal; we could still
+                # rebuild segments from scratch.
+                logger.error(LIBMEMMGR_MAPPED_SEGMENT_BADVERFILE,
+                             self.__map_versions_file, ex)
+                try:            # ignore any error on unlink
+                    os.unlink(self.__map_versions_file)
+                except: pass
+
+        # Prepare validate callables.  To avoid leaving a reference to
+        # this object (the callables will be run in a separate thread), we
+        # now build the file name as string (or None if unknown) and embed
+        # in the callable closures.
+        reader_file = None if self.__reader_ver is None else \
+                      '%s.%d' % (self.__mapped_file_base, self.__reader_ver)
+        writer_file = None if self.__writer_ver is None else \
+                      '%s.%d' % (self.__mapped_file_base, self.__writer_ver)
+        self.__rvalidate_action = \
+            lambda: _validate_mapped_segment_file(reader_file)
+        self.__wvalidate_action = \
+            lambda: _validate_mapped_segment_file(writer_file)
+
+        # If the versions are not yet known, we'll begin with the defaults.
+        if self.__reader_ver is None and self.__writer_ver is None:
+            self.__reader_ver = 0
+            self.__writer_ver = 1
+
+    def get_reset_param(self, utype):
+        # See the description of __reader_file_validated in constructor; we
+        # don't tell readers a possibly broken or non-existent file.
+        if utype == self.READER and not self.__reader_file_validated:
+            return {'mapped-file': None}
+
+        ver = self.__reader_ver if utype == self.READER else self.__writer_ver
         mapped_file = self.__mapped_file_base + '.' + str(ver)
         return {'mapped-file': mapped_file}
 
+    def _start_validate(self):
+        return self.__rvalidate_action, self.__wvalidate_action
+
+    def _complete_validate(self, validated):
+        if validated and self.get_state() == self.R_VALIDATING:
+            self.__reader_file_validated = True
+
     def _switch_versions(self):
         # Swith the versions as noted in the constructor.
+        self.__reader_ver = 1 - self.__reader_ver
         self.__writer_ver = 1 - self.__writer_ver
-
-        if self.__reader_ver is None:
-            self.__reader_ver = 0
-        else:
-            self.__reader_ver = 1 - self.__reader_ver
 
         # Versions should be different
         assert(self.__reader_ver != self.__writer_ver)
+
+        # Now reader file should be ready
+        self.__reader_file_validated = True
+
+        # write/update versions file
+        versions = {'reader': self.__reader_ver, 'writer': self.__writer_ver}
+        try:
+            with open(self.__map_versions_file, 'w') as f:
+                f.write(json.dumps(versions) + '\n')
+        except Exception as ex:
+            logger.error(LIBMEMMGR_MAPPED_SEGMENT_VERFILE_UPDATE_FAIL,
+                         self.__map_versions_file, ex)
 
 class DataSrcInfo:
     """A container for datasrc.ConfigurableClientLists and associated

--- a/src/lib/python/bundy/memmgr/libmemmgr_messages.mes
+++ b/src/lib/python/bundy/memmgr/libmemmgr_messages.mes
@@ -29,10 +29,54 @@ skipped.
 Informational message.  The MemorySegmentBuilder thread received a
 command from the main memmgr thread.
 
-% LIBMEMMGR_BUILDER_SEGMENT_OPEND opened memory segment for update with data source '%1/%2'
-Informational message.  The MemorySegmentBuilder thread opened a
-memory segment used with the shown data source in the read-write mode
+% LIBMEMMGR_BUILDER_RESET_SEGMENT_ERROR Error resetting memory segment for '%1/%2': %3
+The MemorySegmentBuilder thread for memmgr failed to to reset a memory
+segment in the read-write mode for updates.  This is an unexpected
+event, but can still happen if a file-based segment has been corrupted
+and it's not detected in the initial validation.  It's not necessarily
+fatal; the builder thread will try to re-create a new segment and load
+all data from the scratch.  It may take time, but if it's completed
+successfully the memmgr can start working correctly again.
+
+% LIBMEMMGR_BUILDER_SEGMENT_CREATED Re-created memory segment for '%1/%2'
+The MemorySegmentBuilder thread created a new memory segment.  This is
+not an expected event under normal condition, even if reusable segment
+data doesn't exist before, since in that case the reset attempt in the
+read-write mode should have automatically created it.  This explicit
+create operation is therefore a recovery process from an unexpected
+failure.  Although unexpected, it can happen, especially after such
+events as an abrupt system reboot, so unless it happens frequently and
+as long as the creation succeeds this is not a problem.
+
+% LIBMEMMGR_BUILDER_SEGMENT_CREATE_ERROR Error creating memory segment for '%1/%2': %3
+The MemorySegmentBuilder thread created a new memory segment after a
+failure of resetting it, but even the create attempt failed.
+Something should be fundamentally broken, e.g, corruption at the file
+system level, and memmgr itself cannot recover from it by itself.
+The administrator needs to take a closer look at the cause and fix it.
+
+% LIBMEMMGR_BUILDER_SEGMENT_LOAD_ALL Loading all zones instead of just '%1/%2' in a new memory segment for data source '%3'
+The MemorySegmentBuilder thread tried to load a specific zone into a
+memory segment, but due to a failure it had to create a fresh new
+memory segment, and is now going to all zones.  This should normally
+not happen, but can be possible in a recover process from data
+corruption.  See also LIBMEMMGR_BUILDER_SEGMENT_CREATED.
+
+% LIBMEMMGR_BUILDER_SEGMENT_RESET reset memory segment for update with data source '%1/%2'
+Informational message.  The MemorySegmentBuilder thread reset a
+memory segment used with the shown data source to the read-write mode
 for further updates.
+
+% LIBMEMMGR_BUILDER_SEGMENT_VALIDATE Validating memory segment data for data source '%1/%2'
+Informational message.  The memory segment builder thread is
+validating memory segment data in a segment specific way.
+
+% LIBMEMMGR_BUILDER_SEGMENT_VALIDATE_FAIL Failed to validate memory segment data for data source '%1/%2': %3
+An exception occurred when validating a memory segment.  This is
+generally unexpected (errors are expected to be reported without an
+exception), so it's more likely to be a bug of the segment specific
+implementation.  Nevertheless, this is considered a validation failure
+and is reported to the main memmgr thread.
 
 % LIBMEMMGR_BUILDER_ZONE_WRITER_LOAD_1_ERROR Error loading zone '%1', data source '%2': '%3'
 The MemorySegmentBuilder failed to load the specified zone when handling
@@ -42,3 +86,29 @@ the load command. This zone will be skipped.
 An exception occurred when the MemorySegmentBuilder tried to load the
 specified zone when handling the load command. This zone will be
 skipped.
+
+% LIBMEMMGR_MAPPED_SEGMENT_BADVERFILE version file for mapped memory segment '%1' is corrupted: %2
+In the initialization of a mapped-file based memory segment, a corresponding
+version file existed but extracting the versions failed.  This is an
+unexpected error, and the file is probably corrupted.  The version file
+is for optimization, and failure of reading it is not fatal, but it's
+advisable to figure out the cause and fix it.
+
+% LIBMEMMGR_MAPPED_SEGMENT_VALIDATE Validation on mapped memory segment for file %1 %2
+The validation on a file for mapped-memory based memory segment was
+completed.  It shows either success or failure with the corresponding
+file name (if the file name was not known at the time of validation,
+the validation should fail, and '<unknown>' is shown for the file in
+the log message).  In this context, it's considered a 'failure' if the
+file does not exist, but this is actually an expected result if this
+is the first time to generate a mapped file or an existing file has
+been removed for some reason such as data corruption.  In general,
+if the validation fails, the subsequent load phase will create a new
+segment without any content and load all data into it.
+
+% LIBMEMMGR_MAPPED_SEGMENT_VERFILE_UPDATE_FAIL failed to update version file for mapped memory segment '%1': %2
+There was a change in reader/writer versions of a mapped-file based
+memory segment, but updating the version file failed.  This is
+unexpected although not fatal.  See
+LIBMEMMGR_MAPPED_SEGMENT_BADVERFILE; the same explanation and suggestion
+apply.


### PR DESCRIPTION
specifically, it extends the SegmentInfo class (in lib/python/bundy/memmgr/datasrc_info.py) so it has a few more initial states.  See the updated documentation of the class.  Another purpose of this extension is to introduce a separate "version" file, that remembers the latest files for reader and writer.  With these extensions we'll be able to reuse existing mapped file on restart.

bundy-memmgr was also updated so it'll use these extensions.
