### PR TITLE
first step for RRL support: introduced libauth and added RRLKey class

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1561,6 +1561,8 @@ AC_CONFIG_FILES([compatcheck/Makefile
                  src/lib/asiodns/tests/Makefile
                  src/lib/asiolink/Makefile
                  src/lib/asiolink/tests/Makefile
+                 src/lib/auth/Makefile
+                 src/lib/auth/tests/Makefile
                  src/lib/bench/example/Makefile
                  src/lib/bench/Makefile
                  src/lib/bench/tests/Makefile

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -10,6 +10,7 @@ endif # WANT_DHCP
 if WANT_DNS
 
 want_acl = acl
+want_auth = auth
 want_bench = bench
 want_datasrc = datasrc
 want_nsas = nsas
@@ -28,6 +29,6 @@ endif # WANT_DNS
 # variables above and add directories in that order to SUBDIRS.
 SUBDIRS = exceptions util log $(want_hooks) cryptolink dns cc config \
           $(want_acl) $(want_xfr) $(want_bench) asiolink asiodns \
-          $(want_nsas) $(want_cache) $(want_resolve) testutils \
+          $(want_auth) $(want_nsas) $(want_cache) $(want_resolve) testutils \
           $(want_datasrc) $(want_server_common) python $(want_dhcp) \
           $(want_dhcp_ddns) $(want_dhcpsrv) $(want_statistics)

--- a/src/lib/auth/.gitignore
+++ b/src/lib/auth/.gitignore
@@ -1,0 +1,2 @@
+/libauth_messages.cc
+/libauth_messages.h

--- a/src/lib/auth/Makefile.am
+++ b/src/lib/auth/Makefile.am
@@ -1,0 +1,28 @@
+SUBDIRS = . tests
+
+AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+AM_CPPFLAGS += $(BOOST_INCLUDES)
+
+AM_CXXFLAGS = $(B10_CXXFLAGS)
+
+CLEANFILES = *.gcno *.gcda
+
+lib_LTLIBRARIES = libbundy-auth.la
+
+libbundy_auth_la_SOURCES = rrl_key.h rrl_key.cc
+libbundy_auth_la_SOURCES += rrl_response_type.h
+
+libbundy_auth_la_LIBADD = $(top_builddir)/src/lib/exceptions/libbundy-exceptions.la
+libbundy_auth_la_LIBADD += $(top_builddir)/src/lib/asiolink/libbundy-asiolink.la
+libbundy_auth_la_LIBADD += $(top_builddir)/src/lib/dns/libbundy-dns++.la
+libbundy_auth_la_LIBADD += $(top_builddir)/src/lib/log/libbundy-log.la
+
+# notyet:
+# nodist_libbundy_auth_la_SOURCES = libauth_messages.h libauth_messages.cc
+# BUILT_SOURCES = libauth_messages.h libauth_messages.cc
+# libauth_messages.h libauth_messages.cc: Makefile libauth_messages.mes
+# 	$(top_builddir)/src/lib/log/compiler/message $(srcdir)/libauth_messages.mes
+
+# EXTRA_DIST = libauth_messages.mes
+
+CLEANFILES += libauth_messages.h libauth_messages.cc

--- a/src/lib/auth/rrl_key.cc
+++ b/src/lib/auth/rrl_key.cc
@@ -1,0 +1,152 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <auth/rrl_key.h>
+#include <auth/rrl_response_type.h>
+
+#include <exceptions/exceptions.h>
+
+#include <dns/labelsequence.h>
+#include <dns/rrtype.h>
+#include <dns/rrclass.h>
+
+#include <util/io/sockaddr_util.h>
+
+#include <asiolink/io_endpoint.h>
+
+#include <cstring>
+#include <sstream>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+
+using bundy::asiolink::IOEndpoint;
+using bundy::util::io::internal::convertSockAddr;
+
+namespace bundy {
+namespace auth {
+namespace detail {
+
+RRLKey::RRLKey(const IOEndpoint& client_addr, const dns::RRType& qtype,
+               const dns::LabelSequence* qname, const dns::RRClass& qclass,
+               ResponseType resp_type, uint32_t ipv4_mask,
+               const uint32_t ipv6_masks[4], uint32_t hash_seed)
+{
+    memset(&key_, 0, sizeof(key_));
+
+    key_.rtype = resp_type;
+
+    if (resp_type == RESPONSE_QUERY) {
+        key_.qclass = qclass.getCode() & MAX_ENCODED_CLASS_CODE;
+        if (qclass.getCode() > MAX_ENCODED_CLASS_CODE) {
+            key_.big_class = 1;
+        }
+        key_.qtype = qtype.getCode();
+    }
+
+    if (qname) {
+        key_.qname_hash = qname->getFullHash(false, hash_seed);
+    }
+
+    const struct sockaddr& client_sa = client_addr.getSockAddr();
+    switch (client_sa.sa_family) {
+    case AF_INET:
+        key_.ip[0] =
+            (convertSockAddr<sockaddr_in>(&client_sa)->sin_addr.s_addr &
+             ipv4_mask);
+        break;
+    case AF_INET6:
+        key_.ipv6 = 1;
+        std::memcpy(key_.ip,
+                    &convertSockAddr<sockaddr_in6>(&client_sa)->sin6_addr,
+                    sizeof(key_.ip));
+        for (int i = 0; i < 2; ++i) {
+            key_.ip[i] &= ipv6_masks[i];
+        }
+        break;
+    default:
+        // This shouldn't happen since only IPv6 or IPv4 endpoints can be
+        // created via the asiolink API.  But it could be extended or buggy,
+        // so we catch such cases.
+        bundy_throw(bundy::Unexpected,
+                    "unexpected address family for RRLKey: "
+                    << static_cast<int>(client_sa.sa_family));
+    }
+}
+
+std::string
+RRLKey::getIPText(size_t ipv4_prefixlen, size_t ipv6_prefixlen) const {
+    if (ipv4_prefixlen > 32) {
+        bundy_throw(InvalidParameter, "invalid IPv4 prefix len for getIPText: "
+                    << ipv4_prefixlen);
+    }
+    if (ipv6_prefixlen > 128) {
+        bundy_throw(InvalidParameter, "invalid IPv6 prefix len for getIPText: "
+                    << ipv6_prefixlen);
+    }
+
+    struct sockaddr_storage ss;
+    std::memset(&ss, 0, sizeof(ss));
+    struct sockaddr* sa = convertSockAddr<sockaddr_storage>(&ss);
+    if (key_.ipv6) {
+        struct sockaddr_in6* sa6;
+        sa6 = convertSockAddr<sockaddr_in6>(sa);
+        sa6->sin6_family = AF_INET6;
+        sa6->sin6_len = sizeof(*sa6);
+        BOOST_STATIC_ASSERT(sizeof(sa6->sin6_addr) >= sizeof(key_.ip));
+        memcpy(&sa6->sin6_addr, key_.ip, sizeof(key_.ip));
+    } else {
+        struct sockaddr_in* sa4;
+        sa4 = convertSockAddr<sockaddr_in>(sa);
+        sa4->sin_family = AF_INET;
+        sa4->sin_len = sizeof(*sa4);
+        sa4->sin_addr.s_addr = key_.ip[0];
+    }
+    const socklen_t sa_len = key_.ipv6 ?
+        sizeof(sockaddr_in6) : sizeof(sockaddr_in);
+    char hbuf[NI_MAXHOST];
+    if (getnameinfo(sa, sa_len, hbuf, NI_MAXHOST, NULL, 0,
+                    NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+        // This shouldn't happen for any sane getnameinfo implementation, so
+        // we could throw here, but it probably wouldn't be a big deal anyway,
+        // since the returned string will only be used for logging in practice.
+        // So we just return some dummy string.
+        return ("???");
+    }
+
+    std::stringstream sstr;
+    sstr << hbuf;
+    if (key_.ipv6) {
+        if (ipv6_prefixlen < 128) {
+            sstr << '/' << ipv6_prefixlen;
+        }
+    } else if (ipv4_prefixlen < 32) {
+        sstr << '/' << ipv4_prefixlen;
+    }
+
+    return (sstr.str());
+}
+
+std::string
+RRLKey::getClassText() const {
+    if (key_.big_class) {
+        return ("?");
+    }
+    return (dns::RRClass(key_.qclass & MAX_ENCODED_CLASS_CODE).toText());
+}
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy

--- a/src/lib/auth/rrl_key.h
+++ b/src/lib/auth/rrl_key.h
@@ -1,0 +1,195 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#ifndef AUTH_RRL_KEY_H
+#define AUTH_RRL_KEY_H 1
+
+#include <auth/rrl_response_type.h>
+
+#include <dns/labelsequence.h>
+#include <dns/rrtype.h>
+#include <dns/rrclass.h>
+
+#include <boost/functional/hash.hpp>
+#include <boost/static_assert.hpp>
+
+#include <cstring>
+#include <string>
+
+#include <stdint.h>
+
+namespace bundy {
+namespace asiolink {
+class IOEndpoint;
+}
+
+namespace auth {
+namespace detail {
+
+/// \brief RRL entry key.
+///
+/// This class encapsulates keys for RRL entries, containing information
+/// such as query name and type.  It's designed to be efficient both in terms
+/// of memory footprint and access overhead, while providing as much safety
+/// as possible.
+///
+/// Internally, it's implemented a simple structure of trivial type members
+/// with straightforward accessors.  But the layout is hidden in a private
+/// member, and all public methods are const member functions.  In fact, once
+/// constructed, it's guaranteed that the object will be immutable.
+class RRLKey {
+public:
+    /// \brief The default constructor.
+    ///
+    /// This is defined for requirements of STL containers.  We don't
+    /// directly use keys constructed by this.
+    RRLKey() {}
+
+    /// \brief Constructor from key parameters
+    ///
+    /// This is a straightforward constructor that takes values that consist
+    /// of the key, and stores (a copy of) them almost as passed.
+    ///
+    /// The query name, if given (non-NULL), will be stored in the form of a
+    /// hash value to save the space.  Once the RRLKey is constructed, the
+    /// complete information of the original query name will be lost.  The
+    /// hash value is calculated using the given seed value (hash_seed).
+    /// In practice, the use of this class must use the same seed throughout
+    /// its lifetime; however, it's highly advisable to use a reasonably
+    /// unpredictable random value for every run.
+    ///
+    /// This constructor is basically exception free.  The only case it can
+    /// throw is \c client_addr represents neither IPv6 nor IPv4 address, but
+    /// this shouldn't happen due to the restriction of the underlying API.
+    /// Should this ever happen, a bundy::Unexpected exception will be thrown.
+    ///
+    /// \throw Almost none (see description)
+    ///
+    /// \param client_addr A network end point.  Must correspond to IPv4 or
+    /// IPv6 address.
+    /// \param qtype The query type.
+    /// \param qname The query name in the form of \c LabelSequence.  If NULL,
+    /// it means the key does not correspond to a particular name.
+    /// \param qclass The query class.
+    /// \param resp_type The response type in terms of RRL.
+    /// \param ipv4_mask A bit mask to be applied to the address stored in
+    /// client_addr, in case it's an IPv4 address.
+    /// \param ipv6_masks A bit mask to be applied to the address stored in
+    /// client_addr, in case it's an IPv6 address.  In fact, only up to the
+    /// higher 64 bits will be used.
+    /// \param hash_seed A seed value to calculate a hash for qname.
+    RRLKey(const asiolink::IOEndpoint& client_addr, const dns::RRType& qtype,
+           const dns::LabelSequence* qname, const dns::RRClass& qclass,
+           ResponseType resp_type, uint32_t ipv4_mask,
+           const uint32_t ipv6_masks[4], uint32_t hash_seed);
+
+    /// \brief Assignment operator.
+    ///
+    /// \throw None.
+    RRLKey& operator=(const RRLKey& source) {
+        std::memcpy(&key_, &source.key_, sizeof(key_));
+        return (*this);
+    }
+
+    /// \brief Compare this and other RRLKey objects.
+    ///
+    /// \throw None.
+    ///
+    /// \return true if \c this is equal to \c other; false otherwise.
+    bool operator==(const RRLKey& other) const {
+        return (std::memcmp(&key_, &other.key_, sizeof(key_)) == 0);
+    }
+
+    /// \brief Return a hash value of the RRLKey object.
+    ///
+    /// \throw None.
+    ///
+    /// \return a hash value for the stored key.
+    size_t getHash() const {
+        const uint8_t* cp = static_cast<const uint8_t*>(
+            static_cast<const void*>(&key_));
+        return (boost::hash_range(cp, cp + sizeof(key_)));
+    }
+
+    /// \brief Return the response type of the RRLKey object.
+    ///
+    /// It returns the response type specified on construction.
+    ResponseType getResponseType() const {
+        return (static_cast<ResponseType>(key_.rtype));
+    }
+
+    /// \brief Return a textual representation of IP prefix of the key.
+    ///
+    /// The returned string is in the form of <ipv4-or-ipv6 address>[/plen].
+    /// Since the caller may not know the address family of the prefix,
+    /// this method needs to take prefixlen parameters for both cases.
+    /// If it's an IPv6 prefix, ipv6_prefixlen will be used;
+    /// otherwise ipv4_prefixlen will be used.  If the prefixlen is too
+    /// large for the address family, bundy::InvalidParameter will be thrown.
+    std::string getIPText(size_t ipv4_prefixlen, size_t ipv6_prefixlen) const;
+
+    /// \brief Return a textual description of the query class.
+    ///
+    /// Due to internal implementation details not all information of the
+    /// query class is stored in the key; only the lower 6 bits are held.
+    /// If the actual query class value doesn't fit this size, this method
+    /// returns a special string of "?".
+    ///
+    /// If the ResponseType is not RESPONSE_QUERY on construction, the stored
+    /// 7-bit value is always 0.  This method, if called, returns like other
+    /// cases, just treating the value of 0 is the class code.
+    std::string getClassText() const;
+
+    /// \brief Return the query type stored in the key.
+    ///
+    /// If the key is constructed with the response type of RESPONSE_QUERY,
+    /// it returns an \c RRType object identical to the given qtype on
+    /// construction; otherwise it always returns an RRType object whose code
+    /// is 0.
+    dns::RRType getType() const {
+        return (dns::RRType(key_.qtype));
+    }
+
+private:
+    // Actual key elements.  We use a separate struct so this part should
+    // be plain old data and can be safely used with low level <cstring>
+    // APIs (std::memXXX).
+    struct {
+        uint32_t ip[2];            // client IP prefix, up to 64 bits
+        uint32_t qname_hash;       // a hash value of qname
+        uint16_t qtype;            // qtype code value
+        uint8_t ipv6 : 1; // 1 iff ip is an IPv6 address;used for logging
+        uint8_t big_class : 1; // 1 iff qclass code >= (1 << 6)
+        uint8_t qclass : 6;        // least 6 bits of qclass code value
+        uint8_t rtype;             // ResponseType
+    } key_;
+
+    // Mask to limit the range of query class.
+    static const uint8_t MAX_ENCODED_CLASS_CODE = 0x3f;
+};
+
+// Make sure the key objects are as small as we expect; the specific value
+// is not important for the behavior, but it proves our assumption on memory
+// footprint.
+BOOST_STATIC_ASSERT(sizeof(RRLKey) == 16);
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy
+
+#endif // AUTH_RRL_KEY_H
+
+// Local Variables:
+// mode: c++
+// End:

--- a/src/lib/auth/rrl_response_type.h
+++ b/src/lib/auth/rrl_response_type.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#ifndef AUTH_RESPONSE_TYPE_H
+#define AUTH_RESPONSE_TYPE_H 1
+
+#include <stdint.h>
+
+#include <boost/static_assert.hpp>
+
+namespace bundy {
+namespace auth {
+namespace detail {
+
+/// \brief Type of responses in terms of RRL.
+enum ResponseType {
+    RESPONSE_QUERY = 0,
+    RESPONSE_NXDOMAIN,
+    RESPONSE_ERROR,
+    RESPONSE_TYPE_MAX = RESPONSE_ERROR
+};
+
+// Make sure types fit in a 8-bit storage.
+BOOST_STATIC_ASSERT(RESPONSE_TYPE_MAX < 256);
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy
+
+#endif // AUTH_RESPONSE_TYPE_H
+
+// Local Variables:
+// mode: c++
+// End:

--- a/src/lib/auth/tests/.gitignore
+++ b/src/lib/auth/tests/.gitignore
@@ -1,0 +1,1 @@
+/run_unittests

--- a/src/lib/auth/tests/Makefile.am
+++ b/src/lib/auth/tests/Makefile.am
@@ -1,0 +1,27 @@
+AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+AM_CPPFLAGS += $(BOOST_INCLUDES)
+
+AM_CXXFLAGS = $(B10_CXXFLAGS)
+
+CLEANFILES = *.gcno *.gcda
+
+TESTS_ENVIRONMENT = $(LIBTOOL) --mode=execute $(VALGRIND_COMMAND)
+
+# Do not define global tests, use check-local so
+# environment can be set (needed for dynamic loading)
+TESTS =
+if HAVE_GTEST
+TESTS += run_unittests
+
+run_unittests_SOURCES = run_unittests.cc
+run_unittests_SOURCES += rrl_key_unittest.cc
+
+run_unittests_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_INCLUDES)
+run_unittests_LDFLAGS = $(AM_LDFLAGS) $(GTEST_LDFLAGS)
+run_unittests_LDADD = $(top_builddir)/src/lib/dns/libbundy-dns++.la
+run_unittests_LDADD += $(top_builddir)/src/lib/util/unittests/libutil_unittests.la
+run_unittests_LDADD += $(top_builddir)/src/lib/auth/libbundy-auth.la
+
+run_unittests_LDADD += $(GTEST_LDADD)
+endif
+noinst_PROGRAMS = $(TESTS)

--- a/src/lib/auth/tests/rrl_key_unittest.cc
+++ b/src/lib/auth/tests/rrl_key_unittest.cc
@@ -1,0 +1,225 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <auth/rrl_key.h>
+#include <auth/rrl_response_type.h>
+
+#include <dns/name.h>
+#include <dns/rrtype.h>
+#include <dns/rrclass.h>
+
+#include <asiolink/io_endpoint.h>
+#include <asiolink/io_address.h>
+
+#include <exceptions/exceptions.h>
+
+#include <gtest/gtest.h>
+
+#include <boost/scoped_ptr.hpp>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+using namespace bundy::auth::detail;
+using namespace bundy::dns;
+using bundy::asiolink::IOEndpoint;
+using bundy::asiolink::IOAddress;
+
+namespace {
+
+uint32_t
+htonlWrapper(uint32_t val) {
+    return (htonl(val));
+}
+
+// A faked IOEndpoint for an uncommon address family, borrowed from
+// io_endpoint_unittest.
+class TestIOEndpoint : public IOEndpoint {
+    virtual IOAddress getAddress() const {
+        return IOAddress("2001:db8::bad:add");
+    }
+    virtual uint16_t getPort() const { return (42); }
+    virtual short getProtocol() const { return (IPPROTO_UDP); }
+    virtual short getFamily() const { return (AF_UNSPEC); }
+    virtual const struct sockaddr& getSockAddr() const {
+        static struct sockaddr sa_placeholder;
+        return (sa_placeholder);
+    }
+};
+
+const uint32_t MASK4 = htonlWrapper(0xffffff00);
+const uint32_t MASK6[4] = { 0xffffffff, htonlWrapper(0xfffffff0), 0, 0 };
+
+class RRLKeyTest : public ::testing::Test {
+protected:
+    RRLKeyTest() :
+        ep4_(IOEndpoint::create(IPPROTO_UDP, IOAddress("192.0.2.1"), 53210)),
+        ep6_(IOEndpoint::create(IPPROTO_UDP, IOAddress("2001:db8::1"), 53210)),
+        qname_("example.com"), qlabels_(qname_)
+    {}
+
+    boost::scoped_ptr<const IOEndpoint> ep4_;
+    boost::scoped_ptr<const IOEndpoint> ep6_;
+    const Name qname_;
+    const LabelSequence qlabels_;
+};
+
+TEST_F(RRLKeyTest, constructAndCompare) {
+    // Check various patterns of construction and compare
+    const RRLKey key1(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    // Only differing in "host ID" of the address.  the key should be
+    // identical.
+    ep4_.reset(IOEndpoint::create(IPPROTO_UDP, IOAddress("192.0.2.2"), 53));
+    EXPECT_TRUE(key1 == RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                               RESPONSE_QUERY, MASK4, MASK6, 0));
+
+    // If the network is different, it should be a different key.
+    ep4_.reset(IOEndpoint::create(IPPROTO_UDP, IOAddress("192.0.1.1"), 53));
+    EXPECT_FALSE(key1 == RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+
+    // same for IPv6
+    const RRLKey key2(*ep6_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    ep6_.reset(IOEndpoint::create(IPPROTO_UDP, IOAddress("2001:db8::2"), 0));
+    EXPECT_TRUE(key2 == RRLKey(*ep6_, RRType::A(), &qlabels_, RRClass::IN(),
+                               RESPONSE_QUERY, MASK4, MASK6, 0));
+
+    ep6_.reset(IOEndpoint::create(IPPROTO_UDP, IOAddress("2001:db8:0:100::2"),
+                                  53));
+    EXPECT_FALSE(key2 == RRLKey(*ep6_, RRType::A(), &qlabels_, RRClass::IN(),
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+
+    // If type is different keys, are different
+    ep4_.reset(IOEndpoint::create(IPPROTO_UDP, IOAddress("192.0.2.1"), 53));
+    EXPECT_FALSE(key1 == RRLKey(*ep4_, RRType::NS(), &qlabels_, RRClass::IN(),
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+    // same for qname
+    const LabelSequence labels(Name::ROOT_NAME());
+    EXPECT_FALSE(key1 == RRLKey(*ep4_, RRType::NS(), &labels, RRClass::IN(),
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+    // case of names should be ignored
+    const Name name_upper("EXAMPLE.COM");
+    const LabelSequence labels_upper(name_upper);
+    EXPECT_TRUE(key1 == RRLKey(*ep4_, RRType::A(), &labels_upper,
+                               RRClass::IN(), RESPONSE_QUERY, MASK4, MASK6, 0));
+
+    // same for qclass, but only for the least 6 bits and "big class" flag
+    EXPECT_FALSE(key1 == RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::CH(),
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+    EXPECT_FALSE(key1 == RRLKey(*ep4_, RRType::A(), &qlabels_,
+                                RRClass(65), // 65 mod 2^6 == 1, with big flag
+                                RESPONSE_QUERY, MASK4, MASK6, 0));
+    // 129 mod 2^6 == 1, and both have big class flag, so not distinguishable.
+    EXPECT_TRUE(RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass(65),
+                       RESPONSE_QUERY, MASK4, MASK6, 0) ==
+                RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass(129),
+                       RESPONSE_QUERY, MASK4, MASK6, 0));
+    // for responses other than QUERY, qtype and class are ignored
+    const RRLKey key3(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_NXDOMAIN, MASK4, MASK6, 0);
+    EXPECT_TRUE(key3 == RRLKey(*ep4_, RRType::MX(), &qlabels_, RRClass::IN(),
+                               RESPONSE_NXDOMAIN, MASK4, MASK6, 0));
+    EXPECT_TRUE(key3 == RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::CH(),
+                               RESPONSE_NXDOMAIN, MASK4, MASK6, 0));
+    const RRLKey key4(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_ERROR, MASK4, MASK6, 0);
+    EXPECT_TRUE(key4 == RRLKey(*ep4_, RRType::MX(), &qlabels_, RRClass::IN(),
+                               RESPONSE_ERROR, MASK4, MASK6, 0));
+    EXPECT_TRUE(key4 == RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::CH(),
+                               RESPONSE_ERROR, MASK4, MASK6, 0));
+
+    // qname could be omitted
+    const RRLKey key5(*ep4_, RRType::A(), NULL, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    EXPECT_TRUE(key5 == RRLKey(*ep4_, RRType::A(), NULL, RRClass::IN(),
+                               RESPONSE_QUERY, MASK4, MASK6, 0));
+}
+
+TEST_F(RRLKeyTest, badConstruct) {
+    // Unexpected address family of the endpoint.  Shouldn't basically happen,
+    // and should result in an exception.
+    EXPECT_THROW(RRLKey(TestIOEndpoint(), RRType::A(), NULL, RRClass::IN(),
+                        RESPONSE_QUERY, MASK4, MASK6, 0),
+                 bundy::Unexpected);
+}
+
+TEST_F(RRLKeyTest, getHash) {
+    // Equivalent keys should have the same hash
+    const RRLKey key1(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    const RRLKey key2(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    EXPECT_TRUE(key1 == key2);  // check the assumption
+    EXPECT_EQ(key1.getHash(), key2.getHash());
+
+    // inequivalent keys do not necessarily have different hash values, but
+    // we know in these examples they are different (assuming the algorithm
+    // won't change soon).
+    const RRLKey key3(*ep6_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    EXPECT_FALSE(key1 == key3);
+    EXPECT_NE(key1.getHash(), key3.getHash());
+}
+
+TEST_F(RRLKeyTest, getIPText) {
+    // IPv4 prefix or address
+    const RRLKey key1(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    EXPECT_EQ("192.0.2.0/24", key1.getIPText(24, 56));
+    EXPECT_EQ("192.0.2.0", key1.getIPText(32, 56));
+
+    // IPv6 prefix or address
+    const RRLKey key2(*ep6_, RRType::A(), &qlabels_, RRClass::IN(),
+                      RESPONSE_QUERY, MASK4, MASK6, 0);
+    EXPECT_EQ("2001:db8::/56", key2.getIPText(24, 56));
+    EXPECT_EQ("2001:db8::", key2.getIPText(24, 128));
+
+    // invalid prefixlen
+    EXPECT_THROW(key1.getIPText(33, 56), bundy::InvalidParameter);
+    EXPECT_THROW(key1.getIPText(24, 129), bundy::InvalidParameter);
+}
+
+TEST_F(RRLKeyTest, getClassText) {
+    // Some common classes, for both IPv4 and IPv6 (which share a bit
+    // with qclass field of the key)
+    EXPECT_EQ("IN", RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                           RESPONSE_QUERY, MASK4, MASK6, 0).getClassText());
+    EXPECT_EQ("CH", RRLKey(*ep6_, RRType::A(), &qlabels_, RRClass::CH(),
+                           RESPONSE_QUERY, MASK4, MASK6, 0).getClassText());
+    // qclass isn't set for non QUERY types
+    EXPECT_EQ("CLASS0", RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                               RESPONSE_NXDOMAIN, MASK4, MASK6, 0).
+              getClassText());
+    EXPECT_EQ("CLASS0", RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                               RESPONSE_ERROR, MASK4, MASK6, 0).getClassText());
+    // only lower 6 bits are kept
+    EXPECT_EQ("?", RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass((1 << 6) + 1),
+                          RESPONSE_QUERY, MASK4, MASK6, 0).getClassText());
+}
+
+TEST_F(RRLKeyTest, getType) {
+    EXPECT_EQ(RRType::A(),
+              RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                     RESPONSE_QUERY, MASK4, MASK6, 0).getType());
+    // For types other than query, value of 0 is used
+    EXPECT_EQ(RRType(0),
+              RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                     RESPONSE_NXDOMAIN, MASK4, MASK6, 0).getType());
+    EXPECT_EQ(RRType(0),
+              RRLKey(*ep4_, RRType::A(), &qlabels_, RRClass::IN(),
+                     RESPONSE_ERROR, MASK4, MASK6, 0).getType());
+}
+}

--- a/src/lib/auth/tests/run_unittests.cc
+++ b/src/lib/auth/tests/run_unittests.cc
@@ -1,0 +1,25 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <log/logger_support.h>
+#include <util/unittests/run_all.h>
+
+int
+main(int argc, char* argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    bundy::log::initLogger();
+
+    return (bundy::util::unittests::run_all());
+}


### PR DESCRIPTION
This is a first step toward a complete support for RRL.

I've introduced a separate library that will eventually be used from bundy-auth but could also be used as a separate library module for authoritative DNS services.

The added class is quite straightforward port from the BIND 9 implementation, just C++-fied  (and therefore safer) with lots of documentation and unit tests.
