### PR TITLE
Xfrout3b: extract time-consuming ops from XfroutSession

### DIFF
--- a/src/bin/xfrout/tests/xfrout_test.py.in
+++ b/src/bin/xfrout/tests/xfrout_test.py.in
@@ -174,16 +174,6 @@ class MyXfroutSession(XfroutSession):
     def _handle(self):
         pass
 
-    def _close_socket(self):
-        pass
-
-    def _send_data(self, data):
-        size = len(data)
-        total_count = 0
-        while total_count < size:
-            count = self._sock.send(data[total_count:])
-            total_count += count
-
 class Dbserver:
     def __init__(self):
         self._shutdown_event = threading.Event()
@@ -305,6 +295,8 @@ class TestXfroutSessionBase(unittest.TestCase):
         self._make_blocking_history = []
         xfrout.make_blocking = lambda x, y: self.__make_blocking(x, y)
 
+        self.__orig_responder_class = xfrout.XfroutResponder
+
         self.sock = MySocket(socket.AF_INET,socket.SOCK_STREAM)
         self.xfrsess = MyXfroutSession(self.sock, None, Dbserver(),
                                        TSIGKeyRing(),
@@ -328,6 +320,7 @@ class TestXfroutSessionBase(unittest.TestCase):
     def tearDown(self):
         xfrout.make_blocking = self.__orig_make_blocking
         xfrout.get_rrset_len = self.orig_get_rrset_len
+        xfrout.XfroutResponder = self.__orig_responder_class
         # transfer_counter must be always be reset no matter happens within
         # the XfroutSession object.  We check the condition here.
         self.assertEqual(0, self.xfrsess._server.transfer_counter)
@@ -610,19 +603,25 @@ class TestXfroutSession(TestXfroutSessionBase):
                          self.xfrsess._get_transfer_acl(Name('EXAMPLE.COM'),
                                                         RRClass.IN))
 
-    def test_reply_xfrout_query_with_error_rcode(self):
-        msg = self.getmsg()
-        self.xfrsess._reply_query_with_error_rcode(msg, Rcode(3))
-        get_msg = self.sock.read_msg()
-        self.assertEqual(get_msg.get_rcode().to_text(), "NXDOMAIN")
+    def test_reply_with_error_rcode(self):
+        respond_with_rcode_params = []
+        class MyResponder:
+            def __init__(self, sock, *args):
+                self.__sock = sock
 
-        # tsig signed message
-        msg = self.getmsg()
-        self.xfrsess._tsig_ctx = self.create_mock_tsig_ctx(TSIGError.NOERROR)
-        self.xfrsess._reply_query_with_error_rcode(msg, Rcode(3))
-        get_msg = self.sock.read_msg()
-        self.assertEqual(get_msg.get_rcode().to_text(), "NXDOMAIN")
-        self.assertTrue(self.message_has_tsig(get_msg))
+            def respond_with_rcode(self, msg, rcode):
+                respond_with_rcode_params.append((msg, rcode))
+
+        xfrout.XfroutResponder = MyResponder
+
+        # if the passed message is None, the call is no-op
+        self.xfrsess._reply_query_with_error_rcode(None, Rcode.NXDOMAIN)
+        self.assertFalse(respond_with_rcode_params)
+
+        # just check the expected responder method is called (msg content
+        # doesn't matter)
+        self.xfrsess._reply_query_with_error_rcode(True, Rcode.NXDOMAIN)
+        self.assertEqual([(True, Rcode.NXDOMAIN)], respond_with_rcode_params)
 
     def test_get_rrset_len(self):
         self.assertEqual(82, get_rrset_len(self.soa_rrset))
@@ -795,7 +794,7 @@ class TestXfroutSession(TestXfroutSessionBase):
                           self.xfrsess._counters.get,
                           'zones', TEST_RRCLASS_STR,
                           TEST_ZONE_NAME_STR, 'xfrreqdone')
-        self.xfrsess._responder_class = MyResponder
+        xfrout.XfroutResponder = MyResponder
         self.xfrsess.dns_xfrout_start(self.mdata)
         self.assertEqual(self.sock.readsent(), b"success")
         self.assertGreater(self.xfrsess._counters.get(
@@ -1184,6 +1183,21 @@ class TestXfroutResponder(TestXfroutSessionBase):
         self.assertEqual(1, len(answer))
         self.assertTrue(rrsets_equal(create_soa(SOA_CURRENT_VERSION),
                                      answer[0]))
+
+    def test_respond_with_rcode(self):
+        msg = self.getmsg()
+        self.__responder.respond_with_rcode(msg, Rcode(3))
+        get_msg = self.sock.read_msg()
+        self.assertEqual(get_msg.get_rcode().to_text(), "NXDOMAIN")
+
+        # tsig signed message
+        msg = self.getmsg()
+        self.__responder._tsig_ctx = \
+            self.create_mock_tsig_ctx(TSIGError.NOERROR)
+        self.__responder.respond_with_rcode(msg, Rcode(3))
+        get_msg = self.sock.read_msg()
+        self.assertEqual(get_msg.get_rcode().to_text(), "NXDOMAIN")
+        self.assertTrue(self.message_has_tsig(get_msg))
 
 class TestXfroutSessionWithSQLite3(TestXfroutSessionBase):
     '''Tests for XFR-out sessions using an SQLite3 DB.

--- a/src/bin/xfrout/xfrout.py.in
+++ b/src/bin/xfrout/xfrout.py.in
@@ -178,6 +178,17 @@ def make_blocking(filenum, on):
     fcntl.fcntl(filenum, fcntl.F_SETFL, flags)
 
 class XfroutSession():
+    """Handle a single xfrout session.
+
+    This class is responsible for handling an xfrout session:
+    - parse the query
+    - authenticate the client
+    - build response
+    - send response
+    The latter half, which can be time consuming and/or involve blocking
+    operations, is delegated to a helper class, XfroutResponder.
+
+    """
     def __init__(self, sock, request_data, server, tsig_key_ring, remote,
                  default_acl, zone_config, counters,
                  client_class=DataSourceClient):
@@ -192,17 +203,16 @@ class XfroutSession():
         self._request_typestr = None
         self._acl = default_acl
         self._zone_config = zone_config
+        self.ClientClass = client_class # parameterize this for testing
         self._soa = None # will be set in _xfrout_setup or in tests
-        self._iterator = None # will be set to a reader for AXFR
+        self._iterator = None # will be set to an iterator to build response
         self._jnl_reader = None # will be set to a reader for IXFR
         # Creation of self.counters should be done before of
         # invoking self._handle()
         self._counters = counters
-        self._handle()
 
-        # These are parameterized for testing; they are essentially constant.
-        self.ClientClass = client_class
-        self._responder_class = XfroutResponder
+        # Now handle the xfr query.
+        self._handle()
 
     def create_tsig_ctx(self, tsig_record, tsig_key_ring):
         return TSIGContext(tsig_record.get_name(),
@@ -337,33 +347,14 @@ class XfroutSession():
             return self._zone_config[config_key]['transfer_acl']
         return self._acl
 
-    def _send_data(self, data):
-        size = len(data)
-        total_count = 0
-        while total_count < size:
-            count = self._sock.send(data[total_count:])
-            total_count += count
-
-    def _send_message(self, msg, tsig_ctx=None):
-        render = MessageRenderer()
-        # As defined in RFC5936 section3.4, perform case-preserving name
-        # compression for AXFR message.
-        render.set_compress_mode(MessageRenderer.CASE_SENSITIVE)
-        render.set_length_limit(XFROUT_MAX_MESSAGE_SIZE)
-
-        msg.to_wire(render, tsig_ctx)
-
-        header_len = struct.pack('H', socket.htons(render.get_length()))
-        self._send_data(header_len)
-        self._send_data(render.get_data())
-
-    def _reply_query_with_error_rcode(self, msg, rcode_):
+    def _reply_query_with_error_rcode(self, msg, rcode):
         if not msg:
             return # query message is invalid. send nothing back.
 
-        msg.make_response()
-        msg.set_rcode(rcode_)
-        self._send_message(msg, self._tsig_ctx)
+        responder = XfroutResponder(self._sock, self._server, self._soa,
+                                    self._iterator, self._jnl_reader,
+                                    self._tsig_ctx, self._tsig_len)
+        responder.respond_with_rcode(msg, rcode)
 
     def _get_zone_soa(self, zone_name):
         '''Retrieve the SOA RR of the given zone.
@@ -559,10 +550,10 @@ class XfroutSession():
                 self._counters.inc('ixfr_running')
             logger.info(XFROUT_XFR_TRANSFER_STARTED, self._request_typestr,
                         format_addrinfo(self._remote), zone_str)
-            responder = self._responder_class(self._sock, self._server,
-                                              self._soa, self._iterator,
-                                              self._jnl_reader, self._tsig_ctx,
-                                              self._tsig_len)
+            responder = XfroutResponder(self._sock, self._server,
+                                        self._soa, self._iterator,
+                                        self._jnl_reader, self._tsig_ctx,
+                                        self._tsig_len)
             responder.respond(msg)
         except Exception as err:
             # count unixsockets send errors
@@ -582,6 +573,13 @@ class XfroutSession():
                     format_addrinfo(self._remote), zone_str)
 
 class XfroutResponder():
+    """Build and send an xfr response.
+
+    This is a helper class of XfroutSession, and deals with time consuming
+    operations (iterating over possibly large zone data and sending it
+    to the client).
+
+    """
     def __init__(self, sock, server, soa, iterator, jnl_reader, tsig_ctx,
                  tsig_len):
         self._sock = sock
@@ -624,6 +622,11 @@ class XfroutResponder():
         msg.set_header_flag(Message.HEADERFLAG_AA)
         msg.set_header_flag(Message.HEADERFLAG_QR)
         return msg
+
+    def respond_with_rcode(self, msg, rcode):
+        msg.make_response()
+        msg.set_rcode(rcode)
+        self._send_message(msg, self._tsig_ctx)
 
     def respond(self, msg):
         msg.make_response()


### PR DESCRIPTION
This is another round of refactoring of xfrout.

The main change is to extract the part of XfroutSession that builds and sends xfr response into a separate new class, XfroutResponder.  The intent is to eventually make the responder class is the only one run by a separate thread.  That would allow us to use generic data source configuration and (mostly) get rid of sqlite3 specific code.

Some method names were modified, but this is essentially a straightforward refactoring.
