### PR TITLE
Issue39: work around g++ warning on the use of boost::optional

### DIFF
--- a/src/lib/datasrc/memory/zone_data_loader.cc
+++ b/src/lib/datasrc/memory/zone_data_loader.cc
@@ -523,7 +523,7 @@ ZoneDataLoader::ZoneDataLoaderImpl::doLoadCommon(
 
             // Check loaded serial.  Note that if checkZone() passed, we
             // should have SOA in the ZoneData.
-            boost::scoped_ptr<const dns::Serial>new_serial(
+            boost::scoped_ptr<const dns::Serial> new_serial(
                 getSerialFromZoneData(rrclass_, loaded_data));
             if (old_serial_ && *old_serial_ >= *new_serial) {
                 LOG_WARN(logger, DATASRC_MEMORY_LOADED_SERIAL_NOT_INCREASED).


### PR DESCRIPTION
I believe this fixes #39 (the second error reported there).  While the code in this branch worked for me, I don't have an environment that uses this particular version of g++, and I cannot prove it with confidence.  If someone can reproduce the original error and confirm the fix (and review it) that would be highly appreciated.
