### PR TITLE
[rrl] introduced RRLTimeStamp, a ring-buffer container of timestamps

### DIFF
--- a/src/lib/auth/Makefile.am
+++ b/src/lib/auth/Makefile.am
@@ -11,6 +11,7 @@ lib_LTLIBRARIES = libbundy-auth.la
 
 libbundy_auth_la_SOURCES = rrl_key.h rrl_key.cc
 libbundy_auth_la_SOURCES += rrl_response_type.h
+libbundy_auth_la_SOURCES += rrl_timestamps.h
 
 libbundy_auth_la_LIBADD = $(top_builddir)/src/lib/exceptions/libbundy-exceptions.la
 libbundy_auth_la_LIBADD += $(top_builddir)/src/lib/asiolink/libbundy-asiolink.la

--- a/src/lib/auth/rrl_timestamps.h
+++ b/src/lib/auth/rrl_timestamps.h
@@ -1,0 +1,135 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#ifndef AUTH_RRL_TIMESTAMPS_H
+#define AUTH_RRL_TIMESTAMPS_H 1
+
+#include <boost/array.hpp>
+#include <boost/function.hpp>
+
+#include <ctime>
+#include <utility>
+
+namespace bundy {
+namespace auth {
+namespace detail {
+
+/// \brief timestamp set used in RRL operation.
+///
+/// This class maintains a set of reasonably recent value of absolute
+/// timestamps in a form of a ring buffer.
+///
+/// Template parameter BASES_COUNT is the buffer size.
+/// TIMESTAMP_FOREVER specifies the range of time while a base is considered
+/// recent enough.  After that period of seconds passed, it generates a new
+/// timestamp base.
+template <size_t BASES_COUNT, int TIMESTAMP_FOREVER>
+class RRLTimeStampBases {
+    static const int MAX_TIME_TRAVEL = 5;
+    static const int MAX_TIMESTAMP = TIMESTAMP_FOREVER - 1;
+public:
+    /// \brief A functor type to be called when new timestamp base is
+    /// (about to be) generated.
+    ///
+    /// Its parameter is the generation ID of the base to be updated.
+    typedef boost::function<void(size_t)> BaseChangeCallback;
+
+    /// \brief Constructor.
+    ///
+    /// \param initial_ts The initial timestamp to be set to the base.
+    /// In practice, this is the current time on construction.
+    /// \param callback Functor to be called when a base time is changed.
+    RRLTimeStampBases(std::time_t initial_ts, BaseChangeCallback callback) :
+        current_(0), callback_(callback)
+    {
+        for (size_t i = 0; i < BASES_COUNT; ++i) {
+            bases_[i] = initial_ts;
+        }
+    }
+
+    /// \brief Returns the timestamp base appropriate for the given time.
+    ///
+    /// It basically returns the current base timestamp.  But if it's too old
+    /// or if it's in the "distant future" (see deltaTime()), make a new
+    /// timestamp base and return it.  In the latter case it calls the callback
+    /// given on construction with the generation ID of the base to be updated.
+    ///
+    /// Note also that the current base is in (not distant) future than \c now
+    /// depending on how the caller gets it and the timing the base is updated.
+    /// Unless it's in the "distant future", this method does not update the
+    /// base and returns the current base timestamp.
+    ///
+    /// This method returns a pair of the timestamp base and of its generation
+    /// ID.
+    std::pair<std::time_t, size_t>
+    getCurrentBase(std::time_t now) {
+        const int ts = now - bases_[current_];
+        if (ts >= MAX_TIMESTAMP || ts < -MAX_TIME_TRAVEL) {
+            const size_t new_current = (current_ + 1) % BASES_COUNT;
+            callback_(new_current);
+
+            current_ = new_current;
+            bases_[current_] = now;
+        }
+        return (std::pair<std::time_t, size_t>(bases_[current_], current_));
+    }
+
+    /// \brief Return the specified generation of timestamp base.
+    std::time_t getBaseByGen(size_t gen) const {
+        return (bases_.at(gen));
+    }
+
+    /// \brief Utility for calculating difference between times.
+    ///
+    /// It returns the difference between the given current time (\c now)
+    /// and (supposedly) past time (\c timestamp).  If the "past" time is
+    /// in future for more than 5 seconds from \c now, it assumes there's a
+    /// system clock change, and returns a special value of
+    /// \c TIMESTAMP_FOREVER.  Otherwise, it returns 0, considering the
+    /// difference is within a margin.
+    ///
+    /// The algorithm is independent from this class, but refers to its
+    /// constants, so defined here as a static member function.
+    static int
+    deltaTime(std::time_t timestamp, std::time_t now) {
+        const int delta = now - timestamp;
+        if (delta >= 0) {
+            return (delta);
+        }
+
+        // The timestamp is in the future.  That future might result from
+        // re-ordered requests, because we use timestamps on requests
+        // instead of consulting a clock.  Timestamps in the distant future are
+        // assumed to result from clock changes.  When the clock changes to
+        // the past, make existing timestamps appear to be in the past.
+        if (delta < -MAX_TIME_TRAVEL) {
+            return (TIMESTAMP_FOREVER);
+        }
+        return (0);
+    }
+private:
+    boost::array<std::time_t, BASES_COUNT> bases_;
+    size_t current_;
+    const BaseChangeCallback callback_;
+};
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy
+
+#endif // AUTH_RRL_TIMESTAMPS_H
+
+// Local Variables:
+// mode: c++
+// End:

--- a/src/lib/auth/tests/Makefile.am
+++ b/src/lib/auth/tests/Makefile.am
@@ -15,6 +15,7 @@ TESTS += run_unittests
 
 run_unittests_SOURCES = run_unittests.cc
 run_unittests_SOURCES += rrl_key_unittest.cc
+run_unittests_SOURCES += rrl_timestamps_unittest.cc
 
 run_unittests_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_INCLUDES)
 run_unittests_LDFLAGS = $(AM_LDFLAGS) $(GTEST_LDFLAGS)

--- a/src/lib/auth/tests/rrl_timestamps_unittest.cc
+++ b/src/lib/auth/tests/rrl_timestamps_unittest.cc
@@ -1,0 +1,103 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <auth/rrl_timestamps.h>
+
+#include <gtest/gtest.h>
+
+#include <boost/bind.hpp>
+
+#include <stdexcept>
+#include <ctime>
+#include <utility>
+
+using namespace bundy::auth::detail;
+
+namespace {
+
+class RRLTimestampsTest : public ::testing::Test {
+protected:
+    RRLTimestampsTest() :
+        callback_param_(65536), // set to some large dummy value
+        ts_bases_(100, boost::bind(&RRLTimestampsTest::callback, this, _1))
+    {}
+
+    size_t callback_param_;     // remember parameter of the latest callback
+
+    typedef RRLTimeStampBases<4, 4096> TestBases; 
+    TestBases ts_bases_;
+
+    void callback(size_t gen) { callback_param_ = gen; }
+
+};
+
+TEST_F(RRLTimestampsTest, deltaTime) {
+    // Normal case: now > recorded timestamp
+    EXPECT_EQ(10, TestBases::deltaTime(10, 20));
+    // Same if now == timestamp
+    EXPECT_EQ(0, TestBases::deltaTime(10, 10));
+
+    // timestamp is "near future".  diff is considered 0.
+    EXPECT_EQ(0, TestBases::deltaTime(11, 10));
+
+    // timestamp in "distant future" is considered clock changes.
+    EXPECT_EQ(4096, TestBases::deltaTime(16, 10));
+}
+
+TEST_F(RRLTimestampsTest, getCurrentBase) {
+    std::pair<std::time_t, size_t> result;
+    std::time_t now = 100;
+
+    // Initially the current base is stored in the 0-th entry of the ringer
+    // buffer.  If it's sufficiently recent, that pair will be returned.
+    result = ts_bases_.getCurrentBase(now + 5);
+    EXPECT_EQ(100, result.first);
+    EXPECT_EQ(0, result.second);
+    EXPECT_EQ(65536, callback_param_); // callback shouldn't be called
+
+    // If the current base is in "future", the given 'now' is basically
+    // re-interpreted as if it's that future value.
+    result = ts_bases_.getCurrentBase(now - 1);
+    EXPECT_EQ(100, result.first);
+    EXPECT_EQ(0, result.second);
+    EXPECT_EQ(65536, callback_param_);
+
+    // If the current base is too old, the buffer is updated.
+    now += 4095;
+    result = ts_bases_.getCurrentBase(now);
+    EXPECT_EQ(now, result.first);
+    EXPECT_EQ(1, result.second);
+    EXPECT_EQ(1, callback_param_); // callback should be called for 1st gen
+
+    // If the current base is in "far future", it's assumed to result from
+    // clock change and the base is updated, too.
+    now -= 6;
+    result = ts_bases_.getCurrentBase(now);
+    EXPECT_EQ(now, result.first);
+    EXPECT_EQ(2, result.second);
+    EXPECT_EQ(2, callback_param_);
+
+    // With two more updates, it overrides the 0th generation again.
+    EXPECT_EQ(3, ts_bases_.getCurrentBase(now + 4095).second);
+    EXPECT_EQ(0, ts_bases_.getCurrentBase(now + 4095 + 4095).second);
+
+    // Check behavior of getBaseByGen() after some updates
+    EXPECT_EQ(now + 4095 + 4095, ts_bases_.getBaseByGen(0));
+    EXPECT_EQ(4195, ts_bases_.getBaseByGen(1));
+    EXPECT_EQ(4195 - 6, ts_bases_.getBaseByGen(2));
+    EXPECT_EQ(4195 - 6 + 4095, ts_bases_.getBaseByGen(3));
+    // out-of-range generation will result in an exception
+    EXPECT_THROW(ts_bases_.getBaseByGen(4), std::out_of_range);
+}
+}


### PR DESCRIPTION
this is another small utility class that will be used in the main RRL implementation.
