### PR TITLE
[rrl-namepool] introduced a helper 'name pool' class.

### DIFF
--- a/src/lib/auth/Makefile.am
+++ b/src/lib/auth/Makefile.am
@@ -10,6 +10,7 @@ CLEANFILES = *.gcno *.gcda
 lib_LTLIBRARIES = libbundy-auth.la
 
 libbundy_auth_la_SOURCES = rrl_key.h rrl_key.cc
+libbundy_auth_la_SOURCES += rrl_name_pool.h rrl_name_pool.cc
 libbundy_auth_la_SOURCES += rrl_response_type.h
 libbundy_auth_la_SOURCES += rrl_timestamps.h
 

--- a/src/lib/auth/rrl_name_pool.cc
+++ b/src/lib/auth/rrl_name_pool.cc
@@ -1,0 +1,109 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <auth/rrl_name_pool.h>
+
+#include <dns/name.h>
+
+#include <exceptions/exceptions.h>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/intrusive/list.hpp>
+
+#include <vector>
+#include <utility>
+
+namespace bundy {
+namespace auth {
+namespace detail {
+
+namespace {
+struct NameEntry {
+    NameEntry(size_t index_param, const dns::Name& name_param) :
+        index(index_param), name(name_param)
+    {}
+
+    boost::intrusive::list_member_hook<> hook;
+    size_t index;
+    dns::Name name;
+};
+typedef boost::shared_ptr<NameEntry> NameEntryPtr;
+}
+
+struct NamePool::Impl {
+    typedef boost::intrusive::list<
+        NameEntry,
+        boost::intrusive::member_hook<
+            NameEntry, boost::intrusive::list_member_hook<>,
+            &NameEntry::hook> > FreeList;
+    Impl(size_t n_names) : max_names_(n_names) {}
+
+    const size_t max_names_;
+    std::vector<NameEntryPtr> names_;
+    FreeList free_names_;
+};
+
+NamePool::NamePool(size_t n_names) :
+    impl_(new Impl(n_names))
+{}
+
+NamePool::~NamePool() {
+    delete impl_;
+}
+
+const dns::Name*
+NamePool::getName(size_t index) {
+    if (index == impl_->max_names_) {
+        return (NULL);
+    }
+    return (&impl_->names_.at(index)->name);
+}
+
+
+std::pair<bool, size_t>
+NamePool::saveName(const dns::Name& name) {
+    if (!impl_->free_names_.empty()) {
+        NameEntry& entry = impl_->free_names_.front();
+        impl_->free_names_.pop_front();
+        entry.name = name;
+        return (std::pair<bool, size_t>(true, entry.index));
+    }
+    if (impl_->names_.size() == impl_->max_names_) {
+        return (std::pair<bool, size_t>(false, impl_->max_names_));
+    }
+    impl_->names_.push_back(
+        NameEntryPtr(new NameEntry(impl_->names_.size(), name)));
+    return (std::pair<bool, size_t>(true, impl_->names_.back()->index));
+}
+
+void
+NamePool::freeName(size_t index) {
+    if (index == impl_->max_names_) {
+        return;
+    }
+    NameEntry& entry = *impl_->names_.at(index);
+    if (entry.hook.is_linked()) {
+        bundy_throw(InvalidOperation, "NamePool::freeName error: double free");
+    }
+    impl_->free_names_.push_front(entry);
+}
+
+size_t
+NamePool::getSize() const {
+    return (impl_->names_.size() - impl_->free_names_.size());
+}
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy

--- a/src/lib/auth/rrl_name_pool.h
+++ b/src/lib/auth/rrl_name_pool.h
@@ -1,0 +1,103 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#ifndef AUTH_RRL_NAME_POOL_H
+#define AUTH_RRL_NAME_POOL_H 1
+
+#include <dns/dns_fwd.h>
+
+#include <boost/noncopyable.hpp>
+
+#include <utility>
+
+namespace bundy {
+namespace auth {
+namespace detail {
+
+/// \brief A helper pool of dns::Name objects for logging.
+class NamePool : boost::noncopyable {
+public:
+    /// \brief Constructor.
+    ///
+    /// \throw std::bad_alloc memory allocation failed.
+    ///
+    /// \param n_names Max number of names that can be saved in the pool.
+    NamePool(size_t n_names);
+
+    /// \brief Destructor.
+    ~NamePool();
+
+    /// \brief Save a name in the pool.
+    ///
+    /// If the pool already has max number of names (specified on
+    /// construction) this operation fails, and the first element of the
+    /// return value is set to false.
+    ///
+    /// \throw std::bad_alloc memory allocation failed.
+    ///
+    /// \param name A Name object to be saved in the pool.
+    /// \return A pair indicating the result: first element is true iff
+    /// the name can be saved; second element is the pool index for the name
+    /// in case the first element is true.
+    std::pair<bool, size_t> saveName(const dns::Name& name);
+
+    /// \brief Return a name from the pool by index.
+    ///
+    /// \throw std::out_of_range index is not valid as described below.
+    ///
+    /// \param index must be a previously returned index from saveName() or
+    /// the max number of names specified on construction.
+    ///
+    /// \return A non NULL pointer to the saved name object for the index,
+    /// or NULL if index is the max number.
+    const dns::Name* getName(size_t index);
+
+    /// \brief Free a previously saved name so it can be saved for another
+    /// name.
+    ///
+    /// This method does nothing if index is the max number.  This way
+    /// the caller can always call this method whether or not a prior call
+    /// to saveName() succeeded (indicated in the second element of its
+    /// return value).
+    ///
+    /// \throw InvalidOperation the name of the specified index is already
+    /// freed.
+    /// \throw std::out_of_range index is invalid.
+    ///
+    /// \param index The index in the pool for the name to be freed; must be
+    /// a value returned by a previous call to saveName().
+    void freeName(size_t index);
+
+    /// \brief Return the number of pooled names that are in use.
+    ///
+    /// This method can be slow and is only intended to be used for tests or
+    /// other diagnostic purposes.
+    ///
+    /// \throw None
+    size_t getSize() const;
+
+private:
+    struct Impl;
+    Impl* impl_;
+};
+
+} // namespace detail
+} // namespace auth
+} // namespace bundy
+
+#endif // AUTH_RRL_NAME_POOL_H
+
+// Local Variables:
+// mode: c++
+// End:

--- a/src/lib/auth/tests/Makefile.am
+++ b/src/lib/auth/tests/Makefile.am
@@ -16,6 +16,7 @@ TESTS += run_unittests
 run_unittests_SOURCES = run_unittests.cc
 run_unittests_SOURCES += rrl_key_unittest.cc
 run_unittests_SOURCES += rrl_timestamps_unittest.cc
+run_unittests_SOURCES += rrl_name_pool_unittest.cc
 
 run_unittests_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_INCLUDES)
 run_unittests_LDFLAGS = $(AM_LDFLAGS) $(GTEST_LDFLAGS)

--- a/src/lib/auth/tests/rrl_name_pool_unittest.cc
+++ b/src/lib/auth/tests/rrl_name_pool_unittest.cc
@@ -1,0 +1,76 @@
+// Copyright (C) 2013  Internet Systems Consortium, Inc. ("ISC")
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+// OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+#include <auth/rrl_name_pool.h>
+
+#include <dns/name.h>
+
+#include <exceptions/exceptions.h>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+using namespace bundy::auth::detail;
+using namespace bundy::auth;
+using namespace bundy::dns;
+
+namespace {
+
+// This class is simple; a set of basic case tests should suffice.
+TEST(RRLNamePool, tests) {
+    NamePool names(2);
+
+    // Initially pool is empty.  getName() would result in out_of_range,
+    // except for the special value = max size, in which it returns NULL,
+    // indicating the name would have to be saved.
+    EXPECT_EQ(0, names.getSize());
+    EXPECT_THROW(names.getName(0), std::out_of_range);
+    EXPECT_EQ(static_cast<const Name*>(NULL), names.getName(2));
+
+    // We can save up to 2 names, and we can find them.
+    std::pair<bool, size_t> result = names.saveName(Name("example.com"));
+    EXPECT_TRUE(result.first);
+    EXPECT_EQ(0, result.second);
+    EXPECT_EQ(Name("example.com"), *names.getName(0));
+    EXPECT_EQ(1, names.getSize());
+
+    result = names.saveName(Name("example.org"));
+    EXPECT_TRUE(result.first);
+    EXPECT_EQ(1, result.second);
+    EXPECT_EQ(Name("example.org"), *names.getName(1));
+    EXPECT_EQ(2, names.getSize());
+
+    // out-of-range cases still hold
+    EXPECT_THROW(names.getName(3), std::out_of_range);
+    EXPECT_EQ(static_cast<const Name*>(NULL), names.getName(2));
+
+    // No more names can be saved
+    EXPECT_FALSE(names.saveName(Name("example")).first);
+
+    // we can free names; duplicate free attempt would result in exception.
+    names.freeName(0);
+    EXPECT_EQ(1, names.getSize());
+    EXPECT_THROW(names.freeName(0), bundy::InvalidOperation);
+    // if index = max size, freeName() should be nop
+    EXPECT_NO_THROW(names.freeName(2));
+
+    // then we can add another name again.
+    result = names.saveName(Name("example"));
+    EXPECT_TRUE(result.first);
+    EXPECT_EQ(0, result.second);
+    EXPECT_EQ(Name("example"), *names.getName(0));
+    EXPECT_EQ(2, names.getSize());
+}
+}


### PR DESCRIPTION
this class provides a placeholder of names for RRL logging.  the implementation is pretty straightforward.
