### PR TITLE
Fix errors/warning building against Python 3.5.0 with gcc 4.8.3

### DIFF
--- a/src/lib/datasrc/memory/zone_table.cc
+++ b/src/lib/datasrc/memory/zone_table.cc
@@ -143,7 +143,7 @@ findCommon(const Name& name, TreeType& zones, NodeType** nodep) {
     result::Result my_result;
 
     typedef DomainTree<ZoneData> ZoneTableTree;
-    typedef DomainTreeNode<ZoneData> ZoneTableNode;
+    //typedef DomainTreeNode<ZoneData> ZoneTableNode;
 
     // Translate the return codes
     switch (zones.find(name, nodep)) {

--- a/src/lib/dns/python/serial_python.cc
+++ b/src/lib/dns/python/serial_python.cc
@@ -93,6 +93,9 @@ PyNumberMethods Serial_NumberMethods = {
     NULL, //nb_inplace_true_divide;
 
     NULL, //nb_index;
+
+    NULL, //nb_matrix_multiply
+    NULL, //nb_inplace_matrix_multiply
 };
 
 int


### PR DESCRIPTION
zone_table.cc:
    Comment unused local
serial_python.cc:
    Fix for updates to PyNumberMethod, may require ifdef based on python version
