### PR TITLE
hacks required to build on Fedora 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ TAGS
 config.h.in~
 /aclocal.m4
 /autom4te.cache/
+/compile
 /config.guess
 /config.h
 /config.h.in

--- a/src/lib/datasrc/memory/zone_data.h
+++ b/src/lib/datasrc/memory/zone_data.h
@@ -529,7 +529,7 @@ public:
     /// This also means it's not considered NSEC3 signed by default.
     ///
     /// \throw none
-    bool isNSEC3Signed() const { return (nsec3_data_); }
+    bool isNSEC3Signed() const { return (!!nsec3_data_); }
 
     /// \brief Return whether or not the zone data is "empty".
     ///

--- a/src/lib/datasrc/memory/zone_table_segment_mapped.cc
+++ b/src/lib/datasrc/memory/zone_table_segment_mapped.cc
@@ -407,7 +407,7 @@ ZoneTableSegmentMapped::getMemorySegment() {
 bool
 ZoneTableSegmentMapped::isUsable() const {
     // If mem_sgmt_ is not empty, then it is usable.
-    return (mem_sgmt_);
+    return (!!mem_sgmt_);
 }
 
 bool

--- a/src/lib/util/encode/base_n.cc
+++ b/src/lib/util/encode/base_n.cc
@@ -12,6 +12,10 @@
 // OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+// workaround for PFTO (Partial Function Template Ordering) being removed from Boost 1.59
+#define BOOST_PFTO_WRAPPER(T) T
+#define BOOST_MAKE_PFTO_WRAPPER(t) t
+
 #include <util/encode/base32hex_from_binary.h>
 #include <util/encode/binary_from_base32hex.h>
 #include <util/encode/base16_from_binary.h>


### PR DESCRIPTION
A couple questionable hacks I needed to get bundy to build on Fedora 24. In addition, since I'm only interested in playing with the Python libs, I gave up on both DHCP and treating warnings as errors. :-(