### PR TITLE
Make search for best Python 3 setup better

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -340,7 +340,7 @@ case "$host" in
 	;;
 esac
 
-m4_define([_AM_PYTHON_INTERPRETER_LIST], [python python3.4 python3.3 python3.2 python3.1 python3])
+m4_define([_AM_PYTHON_INTERPRETER_LIST], [python3 python3.6 python3.5 python3.4 python])
 AC_ARG_WITH([pythonpath],
 AC_HELP_STRING([--with-pythonpath=PATH],
   [specify an absolute path to python executable when automatic version check (incorrectly) fails]),


### PR DESCRIPTION
* default to "python3", since that is most likely to be correct
* add python3.6 and python3.5 which are now available
* remove python3.3, python3.2, and python3.1 which are no longer maintained