### PR TITLE
a couple of unit test fixes

### DIFF
--- a/src/bin/auth/tests/datasrc_clients_mgr_unittest.cc
+++ b/src/bin/auth/tests/datasrc_clients_mgr_unittest.cc
@@ -48,7 +48,7 @@ shutdownCheck() {
     EXPECT_FALSE(cmd.params);   // no argument
 
     // Finally, the manager should wait for the thread to terminate.
-    EXPECT_TRUE(FakeDataSrcClientsBuilder::thread_waited);
+    EXPECT_TRUE(!!FakeDataSrcClientsBuilder::thread_waited);
 }
 
 // Commonly used pattern of checking member variables shared between the
@@ -175,8 +175,8 @@ TEST(DataSrcClientsMgrTest, holder) {
     mgr.reconfigure(reconfigure_arg);
     {
         TestDataSrcClientsMgr::Holder holder(mgr);
-        EXPECT_TRUE(holder.findClientList(RRClass::IN()));
-        EXPECT_TRUE(holder.findClientList(RRClass::CH()));
+        EXPECT_TRUE(!!holder.findClientList(RRClass::IN()));
+        EXPECT_TRUE(!!holder.findClientList(RRClass::CH()));
         EXPECT_EQ(2, holder.getClasses().size());
     }
     // We need to clear command queue by hand
@@ -190,7 +190,7 @@ TEST(DataSrcClientsMgrTest, holder) {
     mgr.reconfigure(reconfigure_arg);
     {
         TestDataSrcClientsMgr::Holder holder(mgr);
-        EXPECT_TRUE(holder.findClientList(RRClass::IN()));
+        EXPECT_TRUE(!!holder.findClientList(RRClass::IN()));
         EXPECT_FALSE(holder.findClientList(RRClass::CH()));
         EXPECT_EQ(RRClass::IN(), holder.getClasses()[0]);
     }
@@ -355,7 +355,7 @@ TEST(DataSrcClientsMgrTest, wakeup) {
         mgr.run_one();
         EXPECT_TRUE(called);
         EXPECT_EQ(1, tag);
-        EXPECT_TRUE(FakeDataSrcClientsBuilder::callback_queue->empty());
+        EXPECT_TRUE(!!FakeDataSrcClientsBuilder::callback_queue->empty());
 
         called = false;
         // If we wake up and don't push anything, it doesn't break.
@@ -373,7 +373,7 @@ TEST(DataSrcClientsMgrTest, wakeup) {
     }
     EXPECT_TRUE(called);
     EXPECT_EQ(2, tag);
-    EXPECT_TRUE(FakeDataSrcClientsBuilder::callback_queue->empty());
+    EXPECT_TRUE(!!FakeDataSrcClientsBuilder::callback_queue->empty());
 }
 
 TEST(DataSrcClientsMgrTest, realThread) {

--- a/src/bin/auth/tests/datasrc_config_unittest.cc
+++ b/src/bin/auth/tests/datasrc_config_unittest.cc
@@ -146,7 +146,7 @@ protected:
         EXPECT_EQ(1, lists_.size());
     }
     FakeSession session;
-    auto_ptr<ModuleCCSession> mccs;
+    unique_ptr<ModuleCCSession> mccs;
     const string specfile;
     std::map<RRClass, ListPtr> lists_;
     string log_;

--- a/src/bin/auth/tests/query_unittest.cc
+++ b/src/bin/auth/tests/query_unittest.cc
@@ -2716,7 +2716,7 @@ TEST_F(QueryTestForMockOnly, nxdomainWithBadWildcardNSEC3Proof) {
 TEST_P(QueryTest, emptyNameWithNSEC3) {
     enableNSEC3(rrsets_to_add_);
     const Name qname("no.example.com");
-    ASSERT_TRUE(list_->find(qname).finder_);
+    ASSERT_TRUE(!!list_->find(qname).finder_);
     ZoneFinderContextPtr result =
         list_->find(qname).finder_->find(qname, RRType::A(),
                                          ZoneFinder::FIND_DNSSEC);

--- a/src/lib/acl/tests/loader_test.cc
+++ b/src/lib/acl/tests/loader_test.cc
@@ -89,7 +89,7 @@ public:
         EXPECT_NO_THROW(loaded = loader_.loadCheck(
                             Element::fromJSON(definition)));
         boost::shared_ptr<Result> result(dynamic_pointer_cast<Result>(loaded));
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(!!result);
         return (result);
     }
     // Load a check and convert it to named check to examine it

--- a/src/lib/datasrc/tests/client_list_unittest.cc
+++ b/src/lib/datasrc/tests/client_list_unittest.cc
@@ -1061,7 +1061,7 @@ TEST_P(ListTest, checkZoneWriterCatchesExceptions) {
     ConfigurableClientList::ZoneWriterPair
         result(list_->getCachedZoneWriter(Name("example.edu"), true));
     ASSERT_EQ(ConfigurableClientList::ZONE_SUCCESS, result.first);
-    ASSERT_TRUE(result.second);
+    ASSERT_TRUE(!!result.second);
 
     std::string error_msg;
     // Because of the way we called getCachedZoneWriter() with
@@ -1087,7 +1087,7 @@ TEST_P(ListTest, checkZoneWriterThrows) {
     ConfigurableClientList::ZoneWriterPair
         result(list_->getCachedZoneWriter(Name("example.edu"), false));
     ASSERT_EQ(ConfigurableClientList::ZONE_SUCCESS, result.first);
-    ASSERT_TRUE(result.second);
+    ASSERT_TRUE(!!result.second);
 
     std::string error_msg;
     // Because of the way we called getCachedZoneWriter() with
@@ -1351,9 +1351,9 @@ ListTest::accessorIterate(const ConstZoneTableAccessorPtr& accessor,
                           int numZones, const string& zoneName="")
 {
     // Confirm basic iterator behavior.
-    ASSERT_TRUE(accessor);
+    ASSERT_TRUE(!!accessor);
     ZoneTableAccessor::IteratorPtr it = accessor->getIterator();
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
     // Iterator does not guarantee ordering, so we look for the target
     // name anywhere in the table.
     bool found = false;

--- a/src/lib/datasrc/tests/database_unittest.cc
+++ b/src/lib/datasrc/tests/database_unittest.cc
@@ -1256,7 +1256,7 @@ DatabaseClientTest::checkJournal(const std::vector<JournalEntry>& expected) {
             client_->getJournalReader(zone_name,
                                       expected.front().serial_,
                                       expected.back().serial_).second;
-        ASSERT_TRUE(jnl_reader);
+        ASSERT_TRUE(!!jnl_reader);
         ConstRRsetPtr rrset;
         std::vector<JournalEntry>::const_iterator it = expected.begin();
         for (rrset = jnl_reader->getNextDiff();
@@ -1505,7 +1505,7 @@ checkIteratorSequence(ZoneIterator& it, ExpectedRRset expected_sequence[],
     vector<string> expected_rdatas;
     for (size_t i = 0; i < num_rrsets; ++i) {
         const ConstRRsetPtr rrset = it.getNextRRset();
-        ASSERT_TRUE(rrset);
+        ASSERT_TRUE(!!rrset);
 
         expected_rdatas.clear();
         expected_rdatas.push_back(expected_sequence[i].rdata1);
@@ -1593,7 +1593,7 @@ TEST_P(DatabaseClientTest, getSOAFromIterator) {
                        "1234 3600 1800 2419200 7200");
 
     ZoneIteratorPtr it(client_->getIterator(zname_));
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
     checkRRset(it->getSOA(), zname_, qclass_, RRType::SOA(), rrttl_, soa_data);
 
     // Iterate over the zone until we find an SOA.  Although there's a broken
@@ -1605,7 +1605,7 @@ TEST_P(DatabaseClientTest, getSOAFromIterator) {
            rrset->getType() != RRType::SOA()) {
         ;
     }
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     // It should be identical to the result of getSOA().
     rrsetCheck(it->getSOA(), rrset);
 }
@@ -1617,13 +1617,13 @@ TEST_P(DatabaseClientTest, noSOAFromIterator) {
 
     // Then getSOA() should return NULL.
     ZoneIteratorPtr it(client_->getIterator(zname_));
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
     EXPECT_FALSE(it->getSOA());
 }
 
 TEST_P(DatabaseClientTest, iterateThenUpdate) {
     ZoneIteratorPtr it(client_->getIterator(zname_));
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
 
     // Try to empty the zone after getting the iterator.  Depending on the
     // underlying data source, it may result in an exception due to the
@@ -1643,7 +1643,7 @@ TEST_P(DatabaseClientTest, iterateThenUpdate) {
            rrset->getType() != RRType::SOA()) {
         ;
     }
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     // It should be identical to the result of getSOA().
     rrsetCheck(it->getSOA(), rrset);
 }
@@ -1656,7 +1656,7 @@ TEST_P(DatabaseClientTest, updateThenIterateThenUpdate) {
     // Then iterate over it.  It should immediately reach the end, at which
     // point the transaction should be committed.
     ZoneIteratorPtr it(client_->getIterator(zname_));
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
     EXPECT_FALSE(it->getNextRRset());
 
     // So another update attempt should succeed, too.
@@ -1669,8 +1669,8 @@ TEST_P(DatabaseClientTest, updateAfterDeleteIterator) {
     // middle of zone.  The transaction should be canceled (actually no
     // different from commit though) at that point.
     ZoneIteratorPtr it(client_->getIterator(zname_));
-    ASSERT_TRUE(it);
-    EXPECT_TRUE(it->getNextRRset());
+    ASSERT_TRUE(!!it);
+    EXPECT_TRUE(!!it->getNextRRset());
     it.reset();
 
     // So another update attempt should succeed.
@@ -3114,7 +3114,7 @@ TEST_P(DatabaseClientTest, getAll) {
     it->next();
     EXPECT_TRUE(it->isLast());
     ConstRRsetPtr sig(target[a_idx]->getRRsig());
-    ASSERT_TRUE(sig);
+    ASSERT_TRUE(!!sig);
     EXPECT_EQ(RRType::RRSIG(), sig->getType());
     EXPECT_EQ("A 5 3 3600 20000101000000 20000201000000 12345 example.org. "
               "FAKEFAKEFAKE", sig->getRdataIterator()->getCurrent().toText());
@@ -3126,7 +3126,7 @@ TEST_P(DatabaseClientTest, getAll) {
     it->next();
     EXPECT_TRUE(it->isLast());
     sig = target[1 - a_idx]->getRRsig();
-    ASSERT_TRUE(sig);
+    ASSERT_TRUE(!!sig);
     EXPECT_EQ(RRType::RRSIG(), sig->getType());
     EXPECT_EQ("NSEC 5 3 3600 20000101000000 20000201000000 12345 example.org. "
               "FAKEFAKEFAKE", sig->getRdataIterator()->getCurrent().toText());
@@ -3154,7 +3154,7 @@ TEST_P(DatabaseClientTest, getOrigin) {
 
 TEST_P(DatabaseClientTest, updaterFinder) {
     updater_ = client_->getUpdater(zname_, false);
-    ASSERT_TRUE(updater_);
+    ASSERT_TRUE(!!updater_);
 
     // If this update isn't replacing the zone, the finder should work
     // just like the normal find() case.
@@ -3172,7 +3172,7 @@ TEST_P(DatabaseClientTest, updaterFinder) {
     // in the zone until something is added.
     updater_.reset();
     updater_ = client_->getUpdater(zname_, true);
-    ASSERT_TRUE(updater_);
+    ASSERT_TRUE(!!updater_);
     if (is_mock_) {
         DatabaseClient::Finder& finder = dynamic_cast<DatabaseClient::Finder&>(
             updater_->getFinder());
@@ -3316,7 +3316,7 @@ nsec3Check(const vector<ConstRRsetPtr>& expected_rrsets,
     const int zone_id = accessor.getZone(zone_name.toText()).second;
     DatabaseAccessor::IteratorContextPtr itctx =
         accessor.getNSEC3Records(expected_hash, zone_id);
-    ASSERT_TRUE(itctx);
+    ASSERT_TRUE(!!itctx);
 
     // Build a list of matched RRsets and compare the both expected and built
     // ones as sets.
@@ -4046,15 +4046,15 @@ TEST_P(DatabaseClientTest, journalReader) {
         client_->getJournalReader(zname_, 1234, 1235);
     EXPECT_EQ(ZoneJournalReader::SUCCESS, result.first);
     ZoneJournalReaderPtr jnl_reader = result.second;
-    ASSERT_TRUE(jnl_reader);
+    ASSERT_TRUE(!!jnl_reader);
     ConstRRsetPtr rrset = jnl_reader->getNextDiff();
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     rrsetCheck(soa_, rrset);
     rrset = jnl_reader->getNextDiff();
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     rrsetCheck(soa_end, rrset);
     rrset = jnl_reader->getNextDiff();
-    ASSERT_FALSE(rrset);
+    ASSERT_FALSE(!!rrset);
 
     // Once it reaches the end of the sequence, further read attempt will
     // result in exception.
@@ -4186,7 +4186,7 @@ TEST_P(DatabaseClientTest, createZone) {
     ASSERT_EQ(result::NOTFOUND, result.code);
 
     // Adding a new zone; it should work and return true
-    ASSERT_TRUE(client_->createZone(new_name));
+    ASSERT_TRUE(!!client_->createZone(new_name));
     const DataSourceClient::FindResult result2(client_->findZone(new_name));
     ASSERT_EQ(result::SUCCESS, result2.code);
     // And the second call should return false since
@@ -4205,7 +4205,7 @@ TEST_P(DatabaseClientTest, createZoneRollbackOnLocked) {
     // well, and the next attempt should succeed
     updater.reset();
     allowMoreTransaction(true);
-    ASSERT_TRUE(client_->createZone(new_name));
+    ASSERT_TRUE(!!client_->createZone(new_name));
 }
 
 TEST_P(DatabaseClientTest, createZoneRollbackOnExists) {
@@ -4217,7 +4217,7 @@ TEST_P(DatabaseClientTest, createZoneRollbackOnExists) {
     // The first transaction shouldn't leave any state, lock, etc, that
     // would hinder the second attempt.
     allowMoreTransaction(true);
-    ASSERT_TRUE(client_->createZone(new_name));
+    ASSERT_TRUE(!!client_->createZone(new_name));
 }
 
 TEST_P(DatabaseClientTest, deleteZone) {
@@ -4226,7 +4226,7 @@ TEST_P(DatabaseClientTest, deleteZone) {
 
     // Deleting an existing zone; it should work and return true (previously
     // existed and is now deleted)
-    EXPECT_TRUE(client_->deleteZone(zname_));
+    EXPECT_TRUE(!!client_->deleteZone(zname_));
 
     // Now it's not found by findZone
     EXPECT_EQ(result::NOTFOUND, client_->findZone(zname_).code);
@@ -4248,7 +4248,7 @@ TEST_P(DatabaseClientTest, deleteZoneRollbackOnLocked) {
     // well, and the next attempt should succeed
     updater.reset();
     allowMoreTransaction(true);
-    EXPECT_TRUE(client_->deleteZone(zname_));
+    EXPECT_TRUE(!!client_->deleteZone(zname_));
 }
 
 TEST_P(DatabaseClientTest, deleteZoneRollbackOnNotFind) {
@@ -4261,7 +4261,7 @@ TEST_P(DatabaseClientTest, deleteZoneRollbackOnNotFind) {
     // The first transaction shouldn't leave any state, lock, etc, that
     // would hinder the second attempt.
     allowMoreTransaction(true);
-    EXPECT_TRUE(client_->deleteZone(zname_));
+    EXPECT_TRUE(!!client_->deleteZone(zname_));
 }
 
 INSTANTIATE_TEST_CASE_P(, RRsetCollectionTest, ::testing::Values(&mock_param));
@@ -4272,7 +4272,7 @@ TEST_P(RRsetCollectionTest, find) {
     // Test the find() that returns ConstRRsetPtr
     ConstRRsetPtr rrset = collection.find(Name("www.example.org."),
                                           RRClass::IN(), RRType::A());
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
     EXPECT_EQ(RRTTL(3600), rrset->getTTL());
     EXPECT_EQ(RRClass("IN"), rrset->getClass());
@@ -4288,7 +4288,7 @@ TEST_P(RRsetCollectionTest, find) {
 
     // www.example.org exists, with AAAA
     rrset = collection.find(Name("www.example.org"), qclass_, RRType::AAAA());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
 
     // www.example.org with AAAA does not exist in RRClass::CH()
     rrset = collection.find(Name("www.example.org"), RRClass::CH(),
@@ -4302,7 +4302,7 @@ TEST_P(RRsetCollectionTest, find) {
     // "cname.example.org." with type CNAME should return the CNAME RRset
     rrset = collection.find(Name("cname.example.org"), qclass_,
                             RRType::CNAME());
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     EXPECT_EQ(RRType::CNAME(), rrset->getType());
     EXPECT_EQ(Name("cname.example.org"), rrset->getName());
 
@@ -4313,7 +4313,7 @@ TEST_P(RRsetCollectionTest, find) {
     // "dname.example.org." with type DNAME should return the DNAME RRset
     rrset = collection.find(Name("dname.example.org"), qclass_,
                             RRType::DNAME());
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     EXPECT_EQ(RRType::DNAME(), rrset->getType());
     EXPECT_EQ(Name("dname.example.org"), rrset->getName());
 
@@ -4336,7 +4336,7 @@ TEST_P(RRsetCollectionTest, find) {
     // nothing.
     rrset = collection.find(Name("delegation.example.org"), qclass_,
                             RRType::NS());
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     EXPECT_EQ(RRType::NS(), rrset->getType());
     EXPECT_EQ(Name("delegation.example.org"), rrset->getName());
 
@@ -4352,7 +4352,7 @@ TEST_P(RRsetCollectionTest, find) {
     // record.
     rrset = collection.find(Name("*.wild.example.org"), qclass_,
                             RRType::A());
-    ASSERT_TRUE(rrset);
+    ASSERT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
     EXPECT_EQ(Name("*.wild.example.org"), rrset->getName());
 }

--- a/src/lib/datasrc/tests/faked_nsec3.cc
+++ b/src/lib/datasrc/tests/faked_nsec3.cc
@@ -131,7 +131,7 @@ findNSEC3Check(bool expected_matched, uint8_t expected_labels,
               static_cast<int>(result.closest_labels));
 
     vector<ConstRRsetPtr> actual_rrsets;
-    ASSERT_TRUE(result.closest_proof);
+    ASSERT_TRUE(!!result.closest_proof);
     actual_rrsets.push_back(result.closest_proof);
     rrsetsCheck(expected_closest, actual_rrsets.begin(),
                 actual_rrsets.end());
@@ -140,7 +140,7 @@ findNSEC3Check(bool expected_matched, uint8_t expected_labels,
     if (expected_next.empty()) {
         EXPECT_FALSE(result.next_proof);
     } else {
-        ASSERT_TRUE(result.next_proof);
+        ASSERT_TRUE(!!result.next_proof);
         actual_rrsets.push_back(result.next_proof);
         rrsetsCheck(expected_next, actual_rrsets.begin(),
                     actual_rrsets.end());

--- a/src/lib/datasrc/tests/memory/memory_client_unittest.cc
+++ b/src/lib/datasrc/tests/memory/memory_client_unittest.cc
@@ -245,7 +245,7 @@ protected:
     void TearDown() {
         client_.reset();
         ztable_segment_.reset();
-        EXPECT_TRUE(mem_sgmt_.allMemoryDeallocated()); // catch any leak here.
+        EXPECT_TRUE(!!mem_sgmt_.allMemoryDeallocated()); // catch any leak here.
     }
     const RRClass zclass_;
     test::MemorySegmentMock mem_sgmt_;
@@ -322,23 +322,23 @@ TEST_F(MemoryClientTest, loadFromIterator) {
 
     // First we have the SOA
     ConstRRsetPtr rrset(iterator->getNextRRset());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::SOA(), rrset->getType());
 
     // RRType::NS() RRset
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::NS(), rrset->getType());
 
     // RRType::A() RRset
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::MX(), rrset->getType());
     EXPECT_EQ(1, rrset->getRRsigDataCount()); // this RRset is signed
 
     // RRType::MX() RRset
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
     EXPECT_EQ(1, rrset->getRRsigDataCount()); // also signed
 
@@ -752,12 +752,12 @@ TEST_F(MemoryClientTest, getIterator) {
 
     // First we have the SOA
     ConstRRsetPtr rrset(iterator->getNextRRset());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::SOA(), rrset->getType());
 
     // Then the NS
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::NS(), rrset->getType());
 
     // There's nothing else in this iterator
@@ -785,17 +785,17 @@ TEST_F(MemoryClientTest, getIteratorSeparateRRs) {
 
     // First we have the SOA
     ConstRRsetPtr rrset(iterator->getNextRRset());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::SOA(), rrset->getType());
 
     // Then, the NS
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::NS(), rrset->getType());
 
     // Only one RRType::A() RRset
     rrset = iterator->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
 
     // There's nothing else in this zone
@@ -806,22 +806,22 @@ TEST_F(MemoryClientTest, getIteratorSeparateRRs) {
 
     // First we have the SOA
     rrset = iterator2->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::SOA(), rrset->getType());
 
     // Then, the NS
     rrset = iterator2->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::NS(), rrset->getType());
 
     // First RRType::A() RRset
     rrset = iterator2->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
 
     // Second RRType::A() RRset
     rrset = iterator2->getNextRRset();
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
 
     // There's nothing else in this iterator

--- a/src/lib/datasrc/tests/memory/rrset_collection_unittest.cc
+++ b/src/lib/datasrc/tests/memory/rrset_collection_unittest.cc
@@ -67,7 +67,7 @@ TEST_F(RRsetCollectionTest, find) {
     const MemRRsetCollection& ccln = *collection;
     ConstRRsetPtr rrset = ccln.find(Name("www.example.org"), rrclass,
                                     RRType::A());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
     EXPECT_EQ(RRTTL(3600), rrset->getTTL());
     EXPECT_EQ(RRClass("IN"), rrset->getClass());
@@ -83,7 +83,7 @@ TEST_F(RRsetCollectionTest, find) {
 
     // www.example.org exists, with AAAA
     rrset = ccln.find(Name("www.example.org"), rrclass, RRType::AAAA());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
 
     // www.example.org with AAAA does not exist in RRClass::CH()
     rrset = ccln.find(Name("www.example.org"), RRClass::CH(),

--- a/src/lib/datasrc/tests/memory/treenode_rrset_unittest.cc
+++ b/src/lib/datasrc/tests/memory/treenode_rrset_unittest.cc
@@ -170,7 +170,7 @@ checkBasicFields(const AbstractRRset& actual_rrset, const RdataSet* rdataset,
         EXPECT_FALSE(actual_rrset.getRRsig());
     } else {
         ConstRRsetPtr actual_sigrrset = actual_rrset.getRRsig();
-        ASSERT_TRUE(actual_sigrrset);
+        ASSERT_TRUE(!!actual_sigrrset);
         EXPECT_EQ(expected_name, actual_sigrrset->getName());
         EXPECT_EQ(expected_class, actual_sigrrset->getClass());
         EXPECT_EQ(RRType::RRSIG(), actual_sigrrset->getType());

--- a/src/lib/datasrc/tests/memory/zone_finder_unittest.cc
+++ b/src/lib/datasrc/tests/memory/zone_finder_unittest.cc
@@ -368,11 +368,11 @@ private:
             if (!answer) {
                 ASSERT_FALSE(find_result->rrset);
             } else {
-                ASSERT_TRUE(find_result->rrset);
+                ASSERT_TRUE(!!find_result->rrset);
                 ConstRRsetPtr result_rrset(convertRRset(find_result->rrset));
                 rrsetCheck(answer, result_rrset);
                 if (answer_sig && (options & ZoneFinder::FIND_DNSSEC) != 0) {
-                    ASSERT_TRUE(result_rrset->getRRsig());
+                    ASSERT_TRUE(!!result_rrset->getRRsig());
                     rrsetCheck(answer_sig, result_rrset->getRRsig());
                 } else {
                     EXPECT_FALSE(result_rrset->getRRsig());
@@ -399,7 +399,7 @@ private:
 
             // Same for the RRSIG, if any.
             if (answer_sig) {
-                ASSERT_TRUE(result_rrset->getRRsig());
+                ASSERT_TRUE(!!result_rrset->getRRsig());
 
                 RRsetPtr wildsig(new RRset(name, answer_sig->getClass(),
                                            RRType::RRSIG(),
@@ -437,7 +437,7 @@ protected:
         if (!rrset_result) {
             EXPECT_FALSE(find_result->rrset);
         } else {
-            ASSERT_TRUE(find_result->rrset);
+            ASSERT_TRUE(!!find_result->rrset);
             rrsetCheck(rrset_result, convertRRset(find_result->rrset));
         }
         EXPECT_EQ((expected_flags & ZoneFinder::RESULT_WILDCARD) != 0,
@@ -457,7 +457,7 @@ protected:
             // succeed, and the two sets should be "identical".
             const ZoneFinderContextPtr result =
                 finder->find(name, cur_rrset->getType());
-            ASSERT_TRUE(result->rrset);
+            ASSERT_TRUE(!!result->rrset);
             EXPECT_TRUE(result->rrset->isSameKind(*cur_rrset));
         }
         rrsetsCheck(expected_rrsets.begin(), expected_rrsets.end(),
@@ -1737,7 +1737,7 @@ TEST_F(InMemoryZoneFinderNSEC3Test, findNSEC3Walk) {
         EXPECT_EQ(nsec3_data[i].closest_labels, result.closest_labels);
 
         if (nsec3_data[i].closest_proof != NULL) {
-            ASSERT_TRUE(result.closest_proof);
+            ASSERT_TRUE(!!result.closest_proof);
             EXPECT_EQ(Name(nsec3_data[i].closest_proof).concatenate(origin),
                       result.closest_proof->getName());
         } else {
@@ -1745,7 +1745,7 @@ TEST_F(InMemoryZoneFinderNSEC3Test, findNSEC3Walk) {
         }
 
         if (nsec3_data[i].next_proof != NULL) {
-            ASSERT_TRUE(result.next_proof);
+            ASSERT_TRUE(!!result.next_proof);
             EXPECT_EQ(Name(nsec3_data[i].next_proof).concatenate(origin),
                       result.next_proof->getName());
         } else {

--- a/src/lib/datasrc/tests/memory/zone_table_segment_mapped_unittest.cc
+++ b/src/lib/datasrc/tests/memory/zone_table_segment_mapped_unittest.cc
@@ -83,8 +83,8 @@ protected:
     bool verifyData(const MemorySegment& segment);
 
     // Ideally, this should be something similar to a
-    // SegmentObjectHolder, not an auto_ptr.
-    std::auto_ptr<ZoneTableSegment> ztable_segment_;
+    // SegmentObjectHolder, not an unique_ptr.
+    std::unique_ptr<ZoneTableSegment> ztable_segment_;
     const ConstElementPtr config_params_;
     const ConstElementPtr config_params2_;
     std::vector<TestDataElement> test_data_;

--- a/src/lib/datasrc/tests/zone_finder_context_unittest.cc
+++ b/src/lib/datasrc/tests/zone_finder_context_unittest.cc
@@ -136,7 +136,7 @@ protected:
     }
     void SetUp() {
         finder_ = client_->findZone(qzone_).zone_finder;
-        ASSERT_TRUE(finder_);
+        ASSERT_TRUE(!!finder_);
     }
 
     const RRClass qclass_;

--- a/src/lib/datasrc/tests/zone_table_accessor_unittest.cc
+++ b/src/lib/datasrc/tests/zone_table_accessor_unittest.cc
@@ -62,7 +62,7 @@ protected:
 TEST_F(ZoneTableAccessorTest, iteratorFromCache) {
     // Confirm basic iterator behavior.
     ZoneTableAccessor::IteratorPtr it = accessor_.getIterator();
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!it);
     EXPECT_FALSE(it->isLast());
     EXPECT_EQ(0, it->getCurrent().index); // index is always 0 for this version
     EXPECT_EQ(Name("example.com"), it->getCurrent().origin);
@@ -87,8 +87,8 @@ TEST_F(ZoneTableAccessorTest, emptyTable) {
             "{\"cache-enable\": true, \"params\": {}}"), true);
     ZoneTableAccessorCache accessor(empty_config);
     ZoneTableAccessor::IteratorPtr it = accessor.getIterator();
-    ASSERT_TRUE(it);
-    EXPECT_TRUE(it->isLast());
+    ASSERT_TRUE(!!it);
+    EXPECT_TRUE(!!it->isLast());
     EXPECT_THROW(it->getCurrent(), bundy::InvalidOperation);
     EXPECT_THROW(it->next(), bundy::InvalidOperation);
 }
@@ -103,7 +103,7 @@ TEST_F(ZoneTableAccessorTest, disabledTable) {
             " \"cache-zones\": [\"example.com\", \"example.org\"]}"), true);
     ZoneTableAccessorCache accessor(mock_config);
     ZoneTableAccessor::IteratorPtr it = accessor.getIterator();
-    ASSERT_TRUE(it);
+    ASSERT_TRUE(!!it);
     EXPECT_TRUE(it->isLast());
     EXPECT_THROW(it->getCurrent(), bundy::InvalidOperation);
     EXPECT_THROW(it->next(), bundy::InvalidOperation);

--- a/src/lib/dns/tests/message_unittest.cc
+++ b/src/lib/dns/tests/message_unittest.cc
@@ -147,11 +147,11 @@ TEST_F(MessageTest, headerFlag) {
 
     // set operation: by default it will be on
     message_render.setHeaderFlag(Message::HEADERFLAG_QR);
-    EXPECT_TRUE(message_render.getHeaderFlag(Message::HEADERFLAG_QR));
+    EXPECT_TRUE(!!message_render.getHeaderFlag(Message::HEADERFLAG_QR));
 
     // it can be set to on explicitly, too
     message_render.setHeaderFlag(Message::HEADERFLAG_AA, true);
-    EXPECT_TRUE(message_render.getHeaderFlag(Message::HEADERFLAG_AA));
+    EXPECT_TRUE(!!message_render.getHeaderFlag(Message::HEADERFLAG_AA));
 
     // the bit can also be cleared
     message_render.setHeaderFlag(Message::HEADERFLAG_AA, false);
@@ -184,10 +184,10 @@ TEST_F(MessageTest, getEDNS) {
     EXPECT_FALSE(message_parse.getEDNS()); // by default EDNS isn't set
 
     factoryFromFile(message_parse, "message_fromWire10.wire");
-    EXPECT_TRUE(message_parse.getEDNS());
+    EXPECT_TRUE(!!message_parse.getEDNS());
     EXPECT_EQ(0, message_parse.getEDNS()->getVersion());
     EXPECT_EQ(4096, message_parse.getEDNS()->getUDPSize());
-    EXPECT_TRUE(message_parse.getEDNS()->getDNSSECAwareness());
+    EXPECT_TRUE(!!message_parse.getEDNS()->getDNSSECAwareness());
 }
 
 TEST_F(MessageTest, setEDNS) {
@@ -550,10 +550,10 @@ TEST_F(MessageTest, parseHeader) {
     EXPECT_EQ(0x1035, message_parse.getQid());
     EXPECT_EQ(Opcode::QUERY(), message_parse.getOpcode());
     EXPECT_EQ(Rcode::NOERROR(), message_parse.getRcode());
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_QR));
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_AA));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_QR));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_AA));
     EXPECT_FALSE(message_parse.getHeaderFlag(Message::HEADERFLAG_TC));
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_RD));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_RD));
     EXPECT_FALSE(message_parse.getHeaderFlag(Message::HEADERFLAG_RA));
     EXPECT_FALSE(message_parse.getHeaderFlag(Message::HEADERFLAG_AD));
     EXPECT_FALSE(message_parse.getHeaderFlag(Message::HEADERFLAG_CD));
@@ -580,9 +580,9 @@ checkMessageFromWire(const Message& message_parse,
     EXPECT_EQ(0x1035, message_parse.getQid());
     EXPECT_EQ(Opcode::QUERY(), message_parse.getOpcode());
     EXPECT_EQ(Rcode::NOERROR(), message_parse.getRcode());
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_QR));
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_RD));
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_AA));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_QR));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_RD));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_AA));
 
     QuestionPtr q = *message_parse.beginQuestion();
     EXPECT_EQ(test_name, q->getName());
@@ -1034,7 +1034,7 @@ TEST_F(MessageTest, toWireTSIGTruncation3) {
     // scenario.
     InputBuffer buffer(renderer.getData(), renderer.getLength());
     message_parse.fromWire(buffer);
-    EXPECT_TRUE(message_parse.getHeaderFlag(Message::HEADERFLAG_TC));
+    EXPECT_TRUE(!!message_parse.getHeaderFlag(Message::HEADERFLAG_TC));
     // Note that the number of questions are 66, not 67 as we tried to add.
     EXPECT_EQ(66, message_parse.getRRCount(Message::SECTION_QUESTION));
     EXPECT_TRUE(message_parse.getTSIGRecord() != NULL);

--- a/src/lib/dns/tests/rrclass_unittest.cc
+++ b/src/lib/dns/tests/rrclass_unittest.cc
@@ -103,7 +103,7 @@ TEST_F(RRClassTest, toText) {
 
 TEST_F(RRClassTest, createFromText) {
     scoped_ptr<RRClass> chclass(RRClass::createFromText("CH"));
-    EXPECT_TRUE(chclass);
+    EXPECT_TRUE(!!chclass);
     EXPECT_EQ("CH", chclass->toText());
 
     scoped_ptr<RRClass> zzclass(RRClass::createFromText("ZZ"));

--- a/src/lib/dns/tests/rrset_collection_unittest.cc
+++ b/src/lib/dns/tests/rrset_collection_unittest.cc
@@ -59,7 +59,7 @@ template <typename T, typename TP>
 void doFind(T& collection, const RRClass& rrclass) {
     // Test the find() that returns ConstRRsetPtr
     TP rrset = collection.find(Name("www.example.org"), rrclass, RRType::A());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
     EXPECT_EQ(RRType::A(), rrset->getType());
     EXPECT_EQ(RRTTL(3600), rrset->getTTL());
     EXPECT_EQ(RRClass("IN"), rrset->getClass());
@@ -75,7 +75,7 @@ void doFind(T& collection, const RRClass& rrclass) {
 
     // www.example.org exists, with AAAA
     rrset = collection.find(Name("www.example.org"), rrclass, RRType::AAAA());
-    EXPECT_TRUE(rrset);
+    EXPECT_TRUE(!!rrset);
 
     // www.example.org with AAAA does not exist in RRClass::CH()
     rrset = collection.find(Name("www.example.org"), RRClass::CH(),
@@ -110,7 +110,7 @@ doAddAndRemove(RRsetCollection& collection, const RRClass& rrclass) {
     // foo.example.org/A should now exist
     rrset_found = collection.find(Name("foo.example.org"), rrclass,
                                   RRType::A());
-    EXPECT_TRUE(rrset_found);
+    EXPECT_TRUE(!!rrset_found);
     EXPECT_EQ(RRType::A(), rrset_found->getType());
     EXPECT_EQ(RRTTL(7200), rrset_found->getTTL());
     EXPECT_EQ(RRClass("IN"), rrset_found->getClass());

--- a/src/lib/dns/tests/rrttl_unittest.cc
+++ b/src/lib/dns/tests/rrttl_unittest.cc
@@ -100,7 +100,7 @@ TEST_F(RRTTLTest, createFromText) {
     // It returns an actual RRTTL iff the given text is recognized as a
     // valid RR TTL.
     scoped_ptr<RRTTL> good_ttl(RRTTL::createFromText("3600"));
-    EXPECT_TRUE(good_ttl);
+    EXPECT_TRUE(!!good_ttl);
     EXPECT_EQ(RRTTL(3600), *good_ttl);
 
     scoped_ptr<RRTTL> bad_ttl(RRTTL::createFromText("bad"));

--- a/src/lib/server_common/tests/keyring_test.cc
+++ b/src/lib/server_common/tests/keyring_test.cc
@@ -42,7 +42,7 @@ public:
                                        false, false));
     }
     bundy::cc::FakeSession session;
-    std::auto_ptr<ModuleCCSession> mccs;
+    std::unique_ptr<ModuleCCSession> mccs;
     std::string specfile;
     void doInit(bool with_key = true) {
         // Prepare the module specification for it and the config

--- a/src/lib/testutils/srv_test.cc
+++ b/src/lib/testutils/srv_test.cc
@@ -209,7 +209,7 @@ SrvTestBase::ednsBadVers() {
     parsed.fromWire(ib);
     EXPECT_EQ(bundy::dns::Rcode::BADVERS(), parsed.getRcode());
     bundy::dns::ConstEDNSPtr edns(parsed.getEDNS());
-    ASSERT_TRUE(edns);
+    ASSERT_TRUE(!!edns);
     EXPECT_FALSE(edns->getDNSSECAwareness());
 }
 

--- a/src/lib/util/tests/memory_segment_local_unittest.cc
+++ b/src/lib/util/tests/memory_segment_local_unittest.cc
@@ -26,7 +26,7 @@ using namespace bundy::util;
 namespace {
 
 TEST(MemorySegmentLocal, TestLocal) {
-    auto_ptr<MemorySegment> segment(new MemorySegmentLocal());
+    unique_ptr<MemorySegment> segment(new MemorySegmentLocal());
 
     // By default, nothing is allocated.
     EXPECT_TRUE(segment->allMemoryDeallocated());
@@ -57,13 +57,13 @@ TEST(MemorySegmentLocal, TestLocal) {
 }
 
 TEST(MemorySegmentLocal, TestTooMuchMemory) {
-    auto_ptr<MemorySegment> segment(new MemorySegmentLocal());
+    unique_ptr<MemorySegment> segment(new MemorySegmentLocal());
 
     EXPECT_THROW(segment->allocate(ULONG_MAX), bad_alloc);
 }
 
 TEST(MemorySegmentLocal, TestBadDeallocate) {
-    auto_ptr<MemorySegment> segment(new MemorySegmentLocal());
+    unique_ptr<MemorySegment> segment(new MemorySegmentLocal());
 
     // By default, nothing is allocated.
     EXPECT_TRUE(segment->allMemoryDeallocated());
@@ -96,7 +96,7 @@ TEST(MemorySegmentLocal, TestBadDeallocate) {
 }
 
 TEST(MemorySegmentLocal, TestNullDeallocate) {
-    auto_ptr<MemorySegment> segment(new MemorySegmentLocal());
+    unique_ptr<MemorySegment> segment(new MemorySegmentLocal());
 
     // By default, nothing is allocated.
     EXPECT_TRUE(segment->allMemoryDeallocated());


### PR DESCRIPTION
several fixes of EXPECT_TRUE and ASSERT_TRUE that need an real boolean value
migration from auto_ptr to unique_ptr in unittests